### PR TITLE
Allow building in a container

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,9 @@
+FROM registry.fedoraproject.org/fedora:latest
+
+VOLUME /srv/bootupd
+
+WORKDIR /srv/bootupd
+
+RUN dnf update -y && \
+    dnf install -y make cargo rust glib2-devel openssl-devel ostree-devel && \
+    dnf clean all

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 DESTDIR ?=
 PREFIX ?= /usr
 RELEASE ?= 1
+CONTAINER_RUNTIME ?= podman
+IMAGE_PREFIX ?=
+IMAGE_NAME ?= bootupd-build
 
 ifeq ($(RELEASE),1)
         PROFILE ?= release
@@ -10,11 +13,23 @@ else
         CARGO_ARGS =
 endif
 
+ifeq ($(CONTAINER_RUNTIME), podman)
+        IMAGE_PREFIX = localhost/
+endif
+
 units = $(addprefix systemd/, bootupd.service bootupd.socket)
 
 .PHONY: all
 all: $(units)
 	cargo build ${CARGO_ARGS}
+
+.PHONY: create-build-container
+create-build-container:
+	${CONTAINER_RUNTIME} build -t ${IMAGE_NAME} -f Dockerfile.build
+
+.PHONY: build-in-container
+build-in-container: create-build-container
+	${CONTAINER_RUNTIME} run -ti --rm -v .:/srv/bootupd:z ${IMAGE_PREFIX}${IMAGE_NAME} make
 
 .PHONY: install-units
 install-units: $(units)

--- a/README-devel.md
+++ b/README-devel.md
@@ -14,3 +14,30 @@ kola run -E (pwd) --qemu-image fastbuild-fedora-coreos-bootupd-qemu.qcow2  --qem
 ```
 
 See also [the coreos-assembler docs](https://github.com/coreos/coreos-assembler/blob/master/README-devel.md#using-overrides).
+
+## Building With Containers
+
+Many folks use a pet container or toolbox to do development on immutable, partially mutabable, or non-Linux OS's. For those who don't use a pet/toolbox and you'd prefer not to modify your host system for development you can use the `build-in-container` make target to execute building inside a container.
+
+```
+$ make build-in-container
+podman build -t bootupd-build -f Dockerfile.build
+STEP 1: FROM registry.fedoraproject.org/fedora:latest
+STEP 2: VOLUME /srv/bootupd
+--> Using cache a033bf0e43d560e72d7187459d7fad65ab30a1d01c576e8257194d82836472f7
+STEP 3: WORKDIR /srv/bootupd
+--> Using cache 756114416fb4a68e72b68a2097c57d9cb94c830f5b351401319baeafa062695e
+STEP 4: RUN dnf update -y &&     dnf install -y make cargo rust glib2-devel openssl-devel ostree-devel
+--> Using cache a8e2b525ff0701f735e01bb5703c63bb0e67683625093d34be34bf1123a7f954
+STEP 5: COMMIT bootupd-build
+--> a8e2b525ff0
+a8e2b525ff0701f735e01bb5703c63bb0e67683625093d34be34bf1123a7f954
+podman run -ti --rm -v .:/srv/bootupd:z localhost/bootupd-build make
+cargo build --release
+    Updating git repository `https://gitlab.com/cgwalters/ostree-rs`
+    Updating crates.io index
+[...]
+$ ls target/release/bootupd
+target/release/bootupd
+$
+```


### PR DESCRIPTION
Instead of modifying my Silverblue host to get the deps to build `bootupd` I did a quick container image. Since others may benefit from this as well I decided to do some quick `Makefile` updates and send it up to see if it would be helpful.

## New files
- Dockerfile.build: The container recipe used to make the build image

## New make targets
- `create-build-container`: Uses the container runtime to make a build container
- `build-in-container`: Executes make inside the build container

## New make variables
- `CONTAINER_RUNTIME`: Allows overriding what container runtime will be used
