### PR TITLE
bootupd.service: Add ProtectHome=yes

### DIFF
--- a/systemd/bootupd.service
+++ b/systemd/bootupd.service
@@ -1,6 +1,11 @@
 [Unit]
 Description=bootloader update daemon
+Documentation=https://github.com/coreos/bootupd
 
 [Service]
 Type=notify
 ExecStart=/usr/libexec/bootupd daemon
+# On general principle
+ProtectHome=yes
+# So we can remount /boot writable
+MountFlags=slave


### PR DESCRIPTION
One of the benefits of running as a systemd service is getting
simple declarative access to sandboxing/containerization.

Since bootupd should never touch `/home`, let's flip on that
flag.  Also add `MountFlags=slave` in preparation for support
for handling read-only default mounts for `/boot/efi` for example,
like what ostree does for `/sysroot`.