### PR TITLE
Expose binary in /usr/bin/bootupctl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ name = "bootupd"
 path = "src/bootupd.rs"
 
 [[bin]]
-name = "bootupd"
+name = "bootupctl"
 path = "src/main.rs"
 
 [dependencies]

--- a/Makefile
+++ b/Makefile
@@ -37,4 +37,4 @@ install-units: $(units)
 
 .PHONY: install
 install: install-units
-	install -D -t ${DESTDIR}$(PREFIX)/libexec target/${PROFILE}/bootupd
+	install -D -t ${DESTDIR}$(PREFIX)/bin target/${PROFILE}/bootupctl

--- a/packaging/rust-bootupd.spec
+++ b/packaging/rust-bootupd.spec
@@ -36,7 +36,7 @@ License:        ASL 2.0
 %files -n %{crate}
 %license LICENSE
 %doc README.md
-%{_libexecdir}/bootupd
+%{_bindir}/bootupctl
 %{_unitdir}/*
 
 %prep

--- a/systemd/bootupd.service
+++ b/systemd/bootupd.service
@@ -4,7 +4,7 @@ Documentation=https://github.com/coreos/bootupd
 
 [Service]
 Type=notify
-ExecStart=/usr/libexec/bootupd daemon
+ExecStart=/usr/bin/bootupctl daemon
 # On general principle
 ProtectHome=yes
 # So we can remount /boot writable

--- a/tests/kola/test-bootupd
+++ b/tests/kola/test-bootupd
@@ -30,10 +30,6 @@ shim=shimx64.efi
 
 test -f "${efidir}/${shim}"
 
-bootupd() {
-    runv /usr/libexec/bootupd "$@"
-}
-
 prepare_efi_update() {
   test -w /usr
   mkdir -p ${ostbaseefi}
@@ -43,7 +39,7 @@ prepare_efi_update() {
 
 systemctl start bootupd.socket
 
-bootupd status > out.txt
+bootupctl status > out.txt
 assert_file_has_content_literal out.txt 'Component EFI'
 assert_file_has_content_literal out.txt '  Installed: grub2-efi-x64-'
 assert_file_has_content_literal out.txt 'Update: At latest version'
@@ -59,7 +55,7 @@ prepare_efi_update
 # echo somenewfile > ${ostefi}/somenew.efi
 rm -v ${ostefi}/shim.efi
 echo bootupd-test-changes >> ${ostefi}/grubx64.efi
-bootupd generate-update-metadata /
+bootupctl backend generate-update-metadata /
 ver=$(jq -r .version < ${bootupdir}/EFI.json)
 cat >ver.json << EOF
 { "version": "${ver},test" }
@@ -67,17 +63,17 @@ EOF
 jq -s add ${bootupdir}/EFI.json ver.json > new.json
 mv new.json ${bootupdir}/EFI.json
 
-bootupd status | tee out.txt
+bootupctl status | tee out.txt
 assert_file_has_content_literal out.txt 'Component EFI'
 assert_file_has_content_literal out.txt '  Installed: grub2-efi-x64-'
 assert_not_file_has_content out.txt '  Installed: grub2-efi-x64.*,test'
 assert_file_has_content_literal out.txt 'Update: Available:'
 ok update avail
 
-bootupd update | tee out.txt
+bootupctl update | tee out.txt
 assert_file_has_content out.txt 'Updated EFI: grub2-efi-x64.*,test'
 
-bootupd status > out.txt
+bootupctl status > out.txt
 assert_file_has_content_literal out.txt 'Component EFI'
 assert_file_has_content out.txt '  Installed: grub2-efi-x64.*,test'
 assert_file_has_content_literal out.txt 'Update: At latest version'
@@ -94,7 +90,7 @@ fi
 cmp ${bootefidir}/${efisubdir}/shimx64.efi ${efiupdir}/${efisubdir}/shimx64.efi
 ok filesystem changes
 
-bootupd update | tee out.txt
+bootupctl update | tee out.txt
 assert_file_has_content_literal out.txt 'No update available for EFI'
 assert_not_file_has_content_literal out.txt 'Updated EFI'
 


### PR DESCRIPTION
A good way to look at what we need is something much like
systemd's `bootctl` except for shim/grub2.

It's not as nice for admins to explicitly type
`/usr/libexec/bootupd`, plus it intermixes options
with things they shouldn't use.

Split options into frontend (`/usr/bin/bootupctl`) and backend
(things invoked on the build side).  Install via hardlinks
and dispatch by default on `argv[0]`.