### PR TITLE
ci: Fix test script

### DIFF
--- a/ci/build-test.sh
+++ b/ci/build-test.sh
@@ -3,4 +3,4 @@ set -xeuo pipefail
 test -n "${COSA_DIR:-}"
 make
 cosa build-fast
-kola run -E $(pwd) --qemu-image fastbuild-*-qemu.qcow2  --qemu-firmware uefi ext.bootupd
+kola run -E $(pwd) --qemu-image fastbuild-*-qemu.qcow2  --qemu-firmware uefi ext.bootupd.'*'


### PR DESCRIPTION
The test naming convention changed in cosa, let's grab all
the bootupd tests anyways in case we add more.