### PR TITLE
Client refactor

### DIFF
--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -388,15 +388,8 @@ pub fn frontend_main(args: &[&str]) -> Result<()> {
     let opt = Opt::from_iter(args.iter());
     let mut c = ipc::ClientToDaemonConnection::new();
     c.connect()?;
-    let r = c.send(&opt)?;
-    match r {
-        ipc::DaemonToClientReply::Success(buf) => {
-            print!("{}", buf);
-        }
-        ipc::DaemonToClientReply::Failure(buf) => {
-            bail!("{}", buf);
-        }
-    }
+    let r: String = c.send(&opt)?;
+    print!("{}", r);
     c.shutdown()?;
     Ok(())
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -65,9 +65,12 @@ impl ClientToDaemonConnection {
         Ok(())
     }
 
-    pub(crate) fn send<T: serde::de::DeserializeOwned>(&mut self, opt: &crate::Opt) -> Result<T> {
+    pub(crate) fn send<S: serde::ser::Serialize, T: serde::de::DeserializeOwned>(
+        &mut self,
+        msg: &S,
+    ) -> Result<T> {
         {
-            let serialized = bincode::serialize(opt)?;
+            let serialized = bincode::serialize(msg)?;
             let _ = nixsocket::send(self.fd, &serialized, nixsocket::MsgFlags::MSG_CMSG_CLOEXEC)
                 .context("client sending request")?;
         }

--- a/src/model.rs
+++ b/src/model.rs
@@ -46,6 +46,29 @@ pub(crate) struct SavedState {
     pub(crate) pending: Option<BTreeMap<String, ContentMetadata>>,
 }
 
+/// The status of an individual component.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct ComponentStatus {
+    /// Currently installed version
+    pub(crate) installed: ContentMetadata,
+    /// In progress update that was interrupted
+    pub(crate) interrupted: Option<ContentMetadata>,
+    /// Update in the deployed filesystem tree
+    pub(crate) update: Option<ContentMetadata>,
+}
+
+/// Representation of bootupd's worldview at a point in time.
+/// This is intended to be a stable format that is output by `bootupctl status --json`
+/// and parsed by higher level management tools.  Transitively then
+/// everything referenced from here should also be stable.
+#[derive(Serialize, Deserialize, Default, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct Status {
+    /// Maps a component name to status
+    pub(crate) components: BTreeMap<String, ComponentStatus>,
+}
+
 // Should be stored in /usr/lib/bootupd/edges.json
 //#[derive(Serialize, Deserialize, Debug)]
 // #[serde(rename_all = "kebab-case")]

--- a/src/model.rs
+++ b/src/model.rs
@@ -56,6 +56,8 @@ pub(crate) struct ComponentStatus {
     pub(crate) interrupted: Option<ContentMetadata>,
     /// Update in the deployed filesystem tree
     pub(crate) update: Option<ContentMetadata>,
+    /// Is true if the version in `update` is different from `installed`
+    pub(crate) updatable: bool,
 }
 
 /// Representation of bootupd's worldview at a point in time.

--- a/tests/kola/test-bootupd
+++ b/tests/kola/test-bootupd
@@ -70,6 +70,10 @@ assert_not_file_has_content out.txt '  Installed: grub2-efi-x64.*,test'
 assert_file_has_content_literal out.txt 'Update: Available:'
 ok update avail
 
+bootupctl status --json > status.json
+jq -r '.components.EFI.installed.version' < status.json > installed.txt
+assert_file_has_content installed.txt '^grub2-efi-x64'
+
 bootupctl update | tee out.txt
 assert_file_has_content out.txt 'Updated EFI: grub2-efi-x64.*,test'
 

--- a/tests/kola/test-bootupd
+++ b/tests/kola/test-bootupd
@@ -95,7 +95,7 @@ cmp ${bootefidir}/${efisubdir}/shimx64.efi ${efiupdir}/${efisubdir}/shimx64.efi
 ok filesystem changes
 
 bootupctl update | tee out.txt
-assert_file_has_content_literal out.txt 'No update available for EFI'
+assert_file_has_content_literal out.txt 'No update available for any component'
 assert_not_file_has_content_literal out.txt 'Updated EFI'
 
 tap_finish


### PR DESCRIPTION
    Move more update logic to client side
    
    Similar to the previous move of `status`, return a structure
    from the daemon and render it on the client.  This actually
    moves more logic for updating to the client too; the IPC request
    updates just one component, and the client iterates over all
    installed components to update.
    
    This way we also better return "partial" status.

---

    Move formatting of status to client
    
    The way we were just serializing a `String` from daemon → client
    was rather...crude.  Instead have the daemon return a serialized
    status object which we print on the client end.

---

    Rework IPC to use generics
    
    Prep for moving things like printing output to the client.
