### PR TITLE
Fix build on aarch64

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -23,7 +23,7 @@ parallel build: {
   }
 },
 codestyle: {
-  cosaPod {
+  cosaPod(buildroot: true) {
       checkout scm
       shwrap("cargo fmt -- --check")
   }

--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -25,7 +25,7 @@ use structopt::StructOpt;
 // #[cfg(any(target_arch = "x86_64"))]
 // mod bios;
 mod component;
-#[cfg(any(target_arch = "x86_64", target_arch = "arm"))]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 mod efi;
 mod filetree;
 mod ipc;
@@ -121,7 +121,7 @@ pub(crate) fn install(source_root: &str, dest_root: &str) -> Result<()> {
 pub(crate) fn get_components() -> Vec<Box<dyn Component>> {
     let mut components: Vec<Box<dyn Component>> = Vec::new();
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "arm"))]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     components.push(Box::new(efi::EFI::new()));
 
     // #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
I got confused and thought it was "arm" in rust but no it really
is `aarch64`, matching the Fedora naming.

Tested to work in a podman fedora:32 container image on
a RHEL8 host `4.18.0-193.14.3.el8_2.aarch64`.