### PR TITLE
update: Require BOOTUPD_ACCEPT_PREVIEW in environment

### DIFF
--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -364,7 +364,20 @@ fn print_status(status: &Status) {
     }
 }
 
+fn validate_preview_env() -> Result<()> {
+    let v = "BOOTUPD_ACCEPT_PREVIEW";
+    if std::env::var_os(v).is_none() {
+        Err(anyhow::anyhow!(
+            "bootupd is currently alpha; set {}=1 in environment to continue",
+            v
+        ))
+    } else {
+        Ok(())
+    }
+}
+
 fn client_run_update(c: &mut ipc::ClientToDaemonConnection) -> Result<()> {
+    validate_preview_env()?;
     let status: Status = c.send(&ClientRequest::Status)?;
     if status.components.is_empty() {
         println!("No components installed.");

--- a/tests/kola/test-bootupd
+++ b/tests/kola/test-bootupd
@@ -19,6 +19,9 @@ function cleanup () {
   fi
 }
 
+# For now
+export BOOTUPD_ACCEPT_PREVIEW=1
+
 bootefidir=/boot/efi/EFI
 bootupdir=/usr/lib/bootupd/updates
 efiupdir=${bootupdir}/EFI
@@ -78,6 +81,11 @@ ok update avail
 bootupctl status --json > status.json
 jq -r '.components.EFI.installed.version' < status.json > installed.txt
 assert_file_has_content installed.txt '^grub2-efi-x64'
+
+if env -u BOOTUPD_ACCEPT_PREVIEW bootupctl update; then
+  fatal "Ran without BOOTUPD_ACCEPT_PREVIEW"
+fi
+ok required env
 
 bootupctl update | tee out.txt
 assert_file_has_content out.txt 'Updated EFI: grub2-efi-x64.*,test'


### PR DESCRIPTION
Further ensure admins don't accidentally try this until we've
tested it very heavily.