### PR TITLE
Use UTC for serialized timestamp

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -14,7 +14,7 @@ pub(crate) const BOOTUPD_UPDATES_DIR: &str = "usr/lib/bootupd/updates";
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub(crate) struct ContentMetadata {
     /// The timestamp, which is used to determine update availability
-    pub(crate) timestamp: NaiveDateTime,
+    pub(crate) timestamp: DateTime<Utc>,
     /// Human readable version number, like ostree it is not ever parsed, just displayed
     pub(crate) version: Option<String>,
 }


### PR DESCRIPTION
Using local timestamps is obviously broken; while our
build process will probably use UTC, relying on that is
wrong, and clients may not use UTC.

Noticed this while going to do some other work around
comparing `ContentMetadata`.

I did verify that RPM's `%{buildtime}` is UTC - the source
invokes `time(NULL)` and the value isn't interpreted
when printed.