### PR TITLE
Make version number not optional

### DIFF
--- a/src/efi.rs
+++ b/src/efi.rs
@@ -154,7 +154,7 @@ impl Component for EFI {
 
         let meta = ContentMetadata {
             timestamp: **largest_timestamp,
-            version: Some(version),
+            version: version,
         };
         write_update_metadata(sysroot_path, self, &meta)?;
         Ok(meta)

--- a/src/model.rs
+++ b/src/model.rs
@@ -14,7 +14,7 @@ pub(crate) const BOOTUPD_UPDATES_DIR: &str = "usr/lib/bootupd/updates";
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub(crate) struct ContentMetadata {
     /// The timestamp, which is used to determine update availability
-    pub(crate) timestamp: NaiveDateTime,
+    pub(crate) timestamp: DateTime<Utc>,
     /// Human readable version number, like ostree it is not ever parsed, just displayed
     pub(crate) version: Option<String>,
 }

--- a/tests/kola/test-bootupd
+++ b/tests/kola/test-bootupd
@@ -66,7 +66,7 @@ echo bootupd-test-changes >> ${ostefi}/grubx64.efi
 bootupctl backend generate-update-metadata /
 ver=$(jq -r .version < ${bootupdir}/EFI.json)
 cat >ver.json << EOF
-{ "version": "${ver},test" }
+{ "version": "${ver},test", "timestamp": "$(date -u --iso-8601=seconds)" }
 EOF
 jq -s add ${bootupdir}/EFI.json ver.json > new.json
 mv new.json ${bootupdir}/EFI.json


### PR DESCRIPTION
There's no good reason to have version numbers be optional.
They're essential for human understanding of things.

We still use a timestamp around for total ordering.

Rework the model to more precisely keep track of "upgradable".