### PR TITLE
cli: rework into a multicall binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ name = "bootupd"
 path = "src/bootupd.rs"
 
 [[bin]]
-name = "bootupctl"
+name = "bootupd"
 path = "src/main.rs"
 
 [dependencies]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 DESTDIR ?=
 PREFIX ?= /usr
+LIBEXECDIR ?= ${PREFIX}/libexec
 RELEASE ?= 1
 CONTAINER_RUNTIME ?= podman
 IMAGE_PREFIX ?=
@@ -22,6 +23,7 @@ units = $(addprefix systemd/, bootupd.service bootupd.socket)
 .PHONY: all
 all: $(units)
 	cargo build ${CARGO_ARGS}
+	ln -f target/${PROFILE}/bootupd target/${PROFILE}/bootupctl
 
 .PHONY: create-build-container
 create-build-container:
@@ -37,4 +39,6 @@ install-units: $(units)
 
 .PHONY: install
 install: install-units
-	install -D -t ${DESTDIR}$(PREFIX)/bin target/${PROFILE}/bootupctl
+	mkdir -p "${DESTDIR}$(PREFIX)/bin" "${DESTDIR}$(LIBEXECDIR)"
+	install -D -t "${DESTDIR}$(LIBEXECDIR)" target/${PROFILE}/bootupd
+	ln -f ${DESTDIR}$(LIBEXECDIR)/bootupd ${DESTDIR}$(PREFIX)/bin/bootupctl

--- a/packaging/rust-bootupd.spec
+++ b/packaging/rust-bootupd.spec
@@ -37,6 +37,7 @@ License:        ASL 2.0
 %license LICENSE
 %doc README.md
 %{_bindir}/bootupctl
+%{_libexecdir}/bootupd
 %{_unitdir}/*
 
 %prep

--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -21,12 +21,11 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::io::prelude::*;
 use std::path::Path;
-use structopt::StructOpt;
 
 // #[cfg(any(target_arch = "x86_64"))]
 // mod bios;
 mod cli;
-pub use cli::CliOptions;
+pub use cli::MultiCall;
 mod component;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 mod efi;
@@ -44,45 +43,6 @@ mod util;
 pub(crate) const STATEFILE_DIR: &str = "boot";
 pub(crate) const STATEFILE_NAME: &str = "bootupd-state.json";
 pub(crate) const WRITE_LOCK_PATH: &str = "run/bootupd-lock";
-
-#[derive(Debug, Serialize, Deserialize, StructOpt)]
-#[structopt(rename_all = "kebab-case")]
-struct StatusOptions {
-    // Output JSON
-    #[structopt(long)]
-    json: bool,
-}
-
-// Options exposed by `bootupctl backend`
-#[derive(Debug, Serialize, Deserialize, StructOpt)]
-#[structopt(name = "boot-update")]
-#[structopt(rename_all = "kebab-case")]
-enum BackendOpt {
-    /// Install data from available components into a disk image
-    Install {
-        /// Source root
-        #[structopt(long, default_value = "/")]
-        src_root: String,
-        /// Target root
-        dest_root: String,
-    },
-    /// Install data from available components into a filesystem tree
-    GenerateUpdateMetadata {
-        /// Physical root mountpoint
-        sysroot: String,
-    },
-}
-
-// "end user" options, i.e. what people should run on client systems
-#[derive(Debug, Serialize, Deserialize, StructOpt)]
-#[structopt(name = "boot-update")]
-#[structopt(rename_all = "kebab-case")]
-enum Opt {
-    /// Update all components
-    Update,
-    /// Print the current state
-    Status(StatusOptions),
-}
 
 /// A message sent from client to server
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/cli/bootupctl.rs
+++ b/src/cli/bootupctl.rs
@@ -1,17 +1,30 @@
 use crate::ipc::ClientToDaemonConnection;
 use anyhow::Result;
+use structopt::clap::AppSettings;
 use structopt::StructOpt;
 
 /// `bootupctl` sub-commands.
 #[derive(Debug, StructOpt)]
 #[structopt(name = "bootupctl", about = "Bootupd client application")]
 pub enum CtlCommand {
+    // FIXME(lucab): drop this after refreshing
+    // https://github.com/coreos/fedora-coreos-config/pull/595
+    #[structopt(name = "backend", setting = AppSettings::Hidden)]
+    Backend(CtlBackend),
     #[structopt(name = "status", about = "Show components status")]
     Status(StatusOpts),
     #[structopt(name = "update", about = "Update all components")]
     Update,
     #[structopt(name = "validate", about = "Validate system state")]
     Validate,
+}
+
+#[derive(Debug, StructOpt)]
+pub enum CtlBackend {
+    #[structopt(name = "generate-update-metadata", setting = AppSettings::Hidden)]
+    Generate(super::bootupd::GenerateOpts),
+    #[structopt(name = "install", setting = AppSettings::Hidden)]
+    Install(super::bootupd::InstallOpts),
 }
 
 #[derive(Debug, StructOpt)]
@@ -28,6 +41,12 @@ impl CtlCommand {
             CtlCommand::Status(opts) => Self::run_status(opts),
             CtlCommand::Update => Self::run_update(),
             CtlCommand::Validate => Self::run_validate(),
+            CtlCommand::Backend(CtlBackend::Generate(opts)) => {
+                super::bootupd::DCommand::run_generate_meta(opts)
+            }
+            CtlCommand::Backend(CtlBackend::Install(opts)) => {
+                super::bootupd::DCommand::run_install(opts)
+            }
         }
     }
 

--- a/src/cli/bootupctl.rs
+++ b/src/cli/bootupctl.rs
@@ -1,0 +1,71 @@
+use crate::ipc::ClientToDaemonConnection;
+use anyhow::Result;
+use structopt::StructOpt;
+
+/// `bootupctl` sub-commands.
+#[derive(Debug, StructOpt)]
+#[structopt(name = "bootupctl", about = "Bootupd client application")]
+pub enum CtlCommand {
+    #[structopt(name = "status", about = "Show components status")]
+    Status(StatusOpts),
+    #[structopt(name = "update", about = "Update all components")]
+    Update,
+    #[structopt(name = "validate", about = "Validate system state")]
+    Validate,
+}
+
+#[derive(Debug, StructOpt)]
+pub struct StatusOpts {
+    // Output JSON
+    #[structopt(long)]
+    json: bool,
+}
+
+impl CtlCommand {
+    /// Run CLI application.
+    pub fn run(self) -> Result<()> {
+        match self {
+            CtlCommand::Status(opts) => Self::run_status(opts),
+            CtlCommand::Update => Self::run_update(),
+            CtlCommand::Validate => Self::run_validate(),
+        }
+    }
+
+    /// Runner for `status` verb.
+    fn run_status(opts: StatusOpts) -> Result<()> {
+        let mut client = ClientToDaemonConnection::new();
+        client.connect()?;
+
+        let r: crate::Status = client.send(&crate::ClientRequest::Status)?;
+        if opts.json {
+            let stdout = std::io::stdout();
+            let mut stdout = stdout.lock();
+            serde_json::to_writer_pretty(&mut stdout, &r)?;
+        } else {
+            crate::print_status(&r);
+        }
+
+        client.shutdown()?;
+        Ok(())
+    }
+
+    /// Runner for `update` verb.
+    fn run_update() -> Result<()> {
+        let mut client = ClientToDaemonConnection::new();
+        client.connect()?;
+
+        crate::client_run_update(&mut client)?;
+
+        client.shutdown()?;
+        Ok(())
+    }
+
+    /// Runner for `validate` verb.
+    fn run_validate() -> Result<()> {
+        let mut client = ClientToDaemonConnection::new();
+        client.connect()?;
+        crate::client_run_validate(&mut client)?;
+        client.shutdown()?;
+        Ok(())
+    }
+}

--- a/src/cli/bootupd.rs
+++ b/src/cli/bootupd.rs
@@ -39,13 +39,13 @@ impl DCommand {
     }
 
     /// Runner for `generate-install-metadata` verb.
-    fn run_generate_meta(opts: GenerateOpts) -> Result<()> {
+    pub(crate) fn run_generate_meta(opts: GenerateOpts) -> Result<()> {
         crate::generate_update_metadata(&opts.sysroot).context("generating metadata failed")?;
         Ok(())
     }
 
     /// Runner for `install` verb.
-    fn run_install(opts: InstallOpts) -> Result<()> {
+    pub(crate) fn run_install(opts: InstallOpts) -> Result<()> {
         crate::install(&opts.src_root, &opts.dest_root).context("boot data installation failed")?;
         Ok(())
     }

--- a/src/cli/bootupd.rs
+++ b/src/cli/bootupd.rs
@@ -1,0 +1,52 @@
+use anyhow::{Context, Result};
+use structopt::StructOpt;
+
+/// `bootupd` sub-commands.
+#[derive(Debug, StructOpt)]
+#[structopt(name = "bootupd", about = "Bootupd backend commands")]
+pub enum DCommand {
+    #[structopt(name = "daemon", about = "Run service logic")]
+    Daemon,
+    #[structopt(name = "generate-update-metadata", about = "Generate metadata")]
+    GenerateUpdateMetadata(GenerateOpts),
+    #[structopt(name = "install", about = "Install components")]
+    Install(InstallOpts),
+}
+
+#[derive(Debug, StructOpt)]
+pub struct InstallOpts {
+    /// Source root
+    #[structopt(long, default_value = "/")]
+    src_root: String,
+    /// Target root
+    dest_root: String,
+}
+
+#[derive(Debug, StructOpt)]
+pub struct GenerateOpts {
+    /// Physical root mountpoint
+    sysroot: String,
+}
+
+impl DCommand {
+    /// Run CLI application.
+    pub fn run(self) -> Result<()> {
+        match self {
+            DCommand::Daemon => crate::daemon(),
+            DCommand::Install(opts) => Self::run_install(opts),
+            DCommand::GenerateUpdateMetadata(opts) => Self::run_generate_meta(opts),
+        }
+    }
+
+    /// Runner for `generate-install-metadata` verb.
+    fn run_generate_meta(opts: GenerateOpts) -> Result<()> {
+        crate::generate_update_metadata(&opts.sysroot).context("generating metadata failed")?;
+        Ok(())
+    }
+
+    /// Runner for `install` verb.
+    fn run_install(opts: InstallOpts) -> Result<()> {
+        crate::install(&opts.src_root, &opts.dest_root).context("boot data installation failed")?;
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@
 
 use log::LevelFilter;
 use structopt::clap::crate_name;
-use structopt::StructOpt;
 
 /// Binary entrypoint, for both daemon and client logic.
 fn main() {
@@ -13,7 +12,7 @@ fn main() {
 /// CLI logic.
 fn run_cli() -> i32 {
     // Parse command-line options.
-    let cli_opts = bootupd::CliOptions::from_args();
+    let cli_opts = bootupd::MultiCall::from_args();
 
     // Setup logging.
     env_logger::Builder::from_default_env()

--- a/systemd/bootupd.service
+++ b/systemd/bootupd.service
@@ -4,7 +4,7 @@ Documentation=https://github.com/coreos/bootupd
 
 [Service]
 Type=notify
-ExecStart=/usr/bin/bootupctl daemon
+ExecStart=/usr/libexec/bootupd daemon
 # On general principle
 ProtectHome=yes
 # So we can remount /boot writable

--- a/tests/kola/test-bootupd
+++ b/tests/kola/test-bootupd
@@ -66,7 +66,7 @@ prepare_efi_update
 # echo somenewfile > ${ostefi}/somenew.efi
 rm -v ${ostefi}/shim.efi
 echo bootupd-test-changes >> ${ostefi}/grubx64.efi
-bootupctl backend generate-update-metadata /
+/usr/libexec/bootupd generate-update-metadata /
 ver=$(jq -r .version < ${bootupdir}/EFI.json)
 cat >ver.json << EOF
 { "version": "${ver},test", "timestamp": "$(date -u --iso-8601=seconds)" }


### PR DESCRIPTION
This reworks the CLI options parser to branch the inner logic
to accommodate two entrypoints, `bootupd` and `bootupctl`, into
a single multicall binary.