### PR TITLE
Add a `validate` command

### DIFF
--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -89,6 +89,8 @@ enum Opt {
 enum ClientRequest {
     /// Update a component
     Update { component: String },
+    /// Validate a component
+    Validate { component: String },
     /// Print the current state
     Status,
 }
@@ -208,6 +210,20 @@ fn update(name: &str) -> Result<ComponentUpdateResult> {
     })
 }
 
+/// daemon implementation of component validate
+fn validate(name: &str) -> Result<ValidationResult> {
+    let state = get_saved_state("/")?.unwrap_or_else(|| SavedState {
+        ..Default::default()
+    });
+    let component = component::new_from_name(name)?;
+    let inst = if let Some(inst) = state.installed.get(name) {
+        inst.clone()
+    } else {
+        anyhow::bail!("Component {} is not installed", name);
+    };
+    component.validate(&inst)
+}
+
 /// Atomically replace the on-disk state with a new version
 fn update_state(sysroot_dir: &openat::Dir, state: &SavedState) -> Result<()> {
     let subdir = sysroot_dir.sub_dir(STATEFILE_DIR)?;
@@ -296,6 +312,13 @@ fn daemon_process_one(client: &mut ipc::AuthenticatedClient) -> Result<()> {
                 println!("Processing update");
                 bincode::serialize(&match update(component.as_str()) {
                     Ok(v) => ipc::DaemonToClientReply::Success::<ComponentUpdateResult>(v),
+                    Err(e) => ipc::DaemonToClientReply::Failure(format!("{:#}", e)),
+                })?
+            }
+            ClientRequest::Validate { component } => {
+                println!("Processing validate");
+                bincode::serialize(&match validate(component.as_str()) {
+                    Ok(v) => ipc::DaemonToClientReply::Success::<ValidationResult>(v),
                     Err(e) => ipc::DaemonToClientReply::Failure(format!("{:#}", e)),
                 })?
             }
@@ -423,6 +446,34 @@ fn client_run_update(c: &mut ipc::ClientToDaemonConnection) -> Result<()> {
     }
     if !updated {
         println!("No update available for any component.");
+    }
+    Ok(())
+}
+
+fn client_run_validate(c: &mut ipc::ClientToDaemonConnection) -> Result<()> {
+    let status: Status = c.send(&ClientRequest::Status)?;
+    if status.components.is_empty() {
+        println!("No components installed.");
+        return Ok(());
+    }
+    let mut caught_validation_error = false;
+    for (name, _) in status.components.iter() {
+        match c.send(&ClientRequest::Validate {
+            component: name.to_string(),
+        })? {
+            ValidationResult::Valid => {
+                println!("Validated: {}", name);
+            }
+            ValidationResult::Errors(errs) => {
+                for err in errs {
+                    eprintln!("{}", err);
+                }
+                caught_validation_error = true;
+            }
+        }
+    }
+    if caught_validation_error {
+        anyhow::bail!("Caught validation errors");
     }
     Ok(())
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -20,6 +20,7 @@ impl CliOptions {
             CliCommand::Daemon => crate::daemon(),
             CliCommand::Status(opts) => run_status(opts),
             CliCommand::Update => run_update(),
+            CliCommand::Validate => run_validate(),
         }
     }
 }
@@ -35,6 +36,8 @@ pub(crate) enum CliCommand {
     Status(crate::StatusOptions),
     #[structopt(name = "update")]
     Update,
+    #[structopt(name = "validate")]
+    Validate,
 }
 
 /// Runner for `backend` verb.
@@ -80,6 +83,15 @@ fn run_update() -> Result<()> {
 
     crate::client_run_update(&mut client)?;
 
+    client.shutdown()?;
+    Ok(())
+}
+
+/// Runner for `validate` verb.
+fn run_validate() -> Result<()> {
+    let mut client = ClientToDaemonConnection::new();
+    client.connect()?;
+    crate::client_run_validate(&mut client)?;
     client.shutdown()?;
     Ok(())
 }

--- a/src/component.rs
+++ b/src/component.rs
@@ -5,11 +5,19 @@
  */
 
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::Write as IoWrite;
 use std::path::{Path, PathBuf};
 
 use crate::model::*;
+
+#[serde(rename_all = "kebab-case")]
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) enum ValidationResult {
+    Valid,
+    Errors(Vec<String>),
+}
 
 /// A component along with a possible update
 pub(crate) trait Component {
@@ -22,6 +30,8 @@ pub(crate) trait Component {
     fn query_update(&self) -> Result<Option<ContentMetadata>>;
 
     fn run_update(&self, current: &InstalledContent) -> Result<InstalledContent>;
+
+    fn validate(&self, current: &InstalledContent) -> Result<ValidationResult>;
 }
 
 pub(crate) fn new_from_name(name: &str) -> Result<Box<dyn Component>> {

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -163,6 +163,28 @@ impl Component for EFI {
     fn query_update(&self) -> Result<Option<ContentMetadata>> {
         get_component_update("/", self)
     }
+
+    fn validate(&self, current: &InstalledContent) -> Result<ValidationResult> {
+        let currentf = current
+            .filetree
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("No filetree for installed EFI found!"))?;
+        let efidir = openat::Dir::open(&Path::new("/").join(MOUNT_PATH).join("EFI"))?;
+        let diff = currentf.relative_diff_to(&efidir)?;
+        let mut errs = Vec::new();
+        for f in diff.changes.iter() {
+            errs.push(format!("Changed: {}", f));
+        }
+        for f in diff.removals.iter() {
+            errs.push(format!("Removed: {}", f));
+        }
+        assert_eq!(diff.additions.len(), 0);
+        if !errs.is_empty() {
+            Ok(ValidationResult::Errors(errs))
+        } else {
+            Ok(ValidationResult::Valid)
+        }
+    }
 }
 
 #[allow(dead_code)]

--- a/tests/kola/test-bootupd
+++ b/tests/kola/test-bootupd
@@ -48,6 +48,9 @@ assert_file_has_content_literal out.txt '  Installed: grub2-efi-x64-'
 assert_file_has_content_literal out.txt 'Update: At latest version'
 ok status
 
+bootupctl validate | tee out.txt
+ok validate
+
 if env LANG=C.UTF-8 runuser -u bin bootupctl status 2>err.txt; then
   fatal "Was able to bootupctl status as non-root"
 fi
@@ -96,6 +99,9 @@ assert_file_has_content out.txt '  Installed: grub2-efi-x64.*,test'
 assert_file_has_content_literal out.txt 'Update: At latest version'
 ok status after update
 
+bootupctl validate | tee out.txt
+ok validate after update
+
 # FIXME see above
 # assert_file_has_content ${bootefidir}/${efisubdir}/somenew.efi 'somenewfile'
 if test -f ${bootefidir}/${efisubdir}/shim.efi; then 
@@ -110,5 +116,13 @@ ok filesystem changes
 bootupctl update | tee out.txt
 assert_file_has_content_literal out.txt 'No update available for any component'
 assert_not_file_has_content_literal out.txt 'Updated EFI'
+
+echo "some additions" >> ${bootefidir}/${efisubdir}/shimx64.efi
+if bootupctl validate 2>err.txt; then
+  fatal "unexpectedly passed validation"
+fi
+assert_file_has_content err.txt "Changed: ${efisubdir}/shimx64.efi"
+test "$(grep -cEe '^Changed:' err.txt)" = "1"
+ok validate detected changes
 
 tap_finish


### PR DESCRIPTION
Let's add support for checking the on-disk state.  This helps
cross-check our implementation and is also useful for administrators
(ref `ostree fsck`, `rpm -V` etc).