### PR TITLE
efi: Do check ESP is FAT

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -33,10 +33,6 @@ pub(crate) fn getenv_utf8(n: &str) -> Result<Option<String>> {
     }
 }
 
-pub(crate) fn running_in_test_suite() -> bool {
-    !nix::unistd::getuid().is_root()
-}
-
 pub(crate) fn filenames(dir: &openat::Dir) -> Result<HashSet<String>> {
     let mut ret = HashSet::new();
     for entry in dir.list_dir(".")? {


### PR DESCRIPTION
After refactoring this method was lying around as `#[allow(dead_code)]`.
Previously we were trying to use Rust unit tests more but
now we favor the real kola tests.

Let's use it again to double-check we're operating on the
right thing.