### PR TITLE
cli: add flag to control logging level

### DIFF
--- a/src/cli/bootupd.rs
+++ b/src/cli/bootupd.rs
@@ -1,10 +1,35 @@
 use anyhow::{Context, Result};
+use log::LevelFilter;
 use structopt::StructOpt;
 
 /// `bootupd` sub-commands.
 #[derive(Debug, StructOpt)]
 #[structopt(name = "bootupd", about = "Bootupd backend commands")]
-pub enum DCommand {
+pub struct DCommand {
+    /// Verbosity level (higher is more verbose).
+    #[structopt(short = "v", parse(from_occurrences), global = true)]
+    verbosity: u8,
+
+    /// CLI sub-command.
+    #[structopt(subcommand)]
+    pub cmd: DVerb,
+}
+
+impl DCommand {
+    /// Return the log-level set via command-line flags.
+    pub(crate) fn loglevel(&self) -> LevelFilter {
+        match self.verbosity {
+            0 => LevelFilter::Warn,
+            1 => LevelFilter::Info,
+            2 => LevelFilter::Debug,
+            _ => LevelFilter::Trace,
+        }
+    }
+}
+
+/// CLI sub-commands.
+#[derive(Debug, StructOpt)]
+pub enum DVerb {
     #[structopt(name = "daemon", about = "Run service logic")]
     Daemon,
     #[structopt(name = "generate-update-metadata", about = "Generate metadata")]
@@ -31,10 +56,10 @@ pub struct GenerateOpts {
 impl DCommand {
     /// Run CLI application.
     pub fn run(self) -> Result<()> {
-        match self {
-            DCommand::Daemon => crate::daemon::run_coreloop(),
-            DCommand::Install(opts) => Self::run_install(opts),
-            DCommand::GenerateUpdateMetadata(opts) => Self::run_generate_meta(opts),
+        match self.cmd {
+            DVerb::Daemon => crate::daemon::run_coreloop(),
+            DVerb::Install(opts) => Self::run_install(opts),
+            DVerb::GenerateUpdateMetadata(opts) => Self::run_generate_meta(opts),
         }
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 //! Command-line interface (CLI) logic.
 
 use anyhow::Result;
+use log::LevelFilter;
 use structopt::StructOpt;
 
 mod bootupctl;
@@ -14,19 +15,19 @@ pub enum MultiCall {
 }
 
 impl MultiCall {
-    pub fn from_args() -> Self {
+    pub fn from_args(args: Vec<String>) -> Self {
         use std::os::unix::ffi::OsStrExt;
 
         // This is a multicall binary, dispatched based on the introspected
         // filename found in argv[0].
         let exe_name = {
-            let arg0 = std::env::args().nth(0).unwrap_or_default();
+            let arg0 = args.get(0).cloned().unwrap_or_default();
             let exe_path = std::path::PathBuf::from(arg0);
             exe_path.file_name().unwrap_or_default().to_os_string()
         };
         match exe_name.as_bytes() {
-            b"bootupctl" => MultiCall::Ctl(bootupctl::CtlCommand::from_args()),
-            b"bootupd" | _ => MultiCall::D(bootupd::DCommand::from_args()),
+            b"bootupctl" => MultiCall::Ctl(bootupctl::CtlCommand::from_iter(args)),
+            b"bootupd" | _ => MultiCall::D(bootupd::DCommand::from_iter(args)),
         }
     }
 
@@ -35,5 +36,59 @@ impl MultiCall {
             MultiCall::Ctl(ctl_cmd) => ctl_cmd.run(),
             MultiCall::D(d_cmd) => d_cmd.run(),
         }
+    }
+
+    /// Return the log-level set via command-line flags.
+    pub fn loglevel(&self) -> LevelFilter {
+        match self {
+            MultiCall::Ctl(cmd) => cmd.loglevel(),
+            MultiCall::D(cmd) => cmd.loglevel(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_multicall_dispatch() {
+        {
+            let d_argv = vec!["/usr/bin/bootupd".to_string(), "daemon".to_string()];
+            let cli = MultiCall::from_args(d_argv);
+            match cli {
+                MultiCall::Ctl(cmd) => panic!(cmd),
+                MultiCall::D(_) => {}
+            };
+        }
+        {
+            let ctl_argv = vec!["/usr/bin/bootupctl".to_string(), "validate".to_string()];
+            let cli = MultiCall::from_args(ctl_argv);
+            match cli {
+                MultiCall::Ctl(_) => {}
+                MultiCall::D(cmd) => panic!(cmd),
+            };
+        }
+        {
+            let ctl_argv = vec!["/bin-mount/bootupctl".to_string(), "validate".to_string()];
+            let cli = MultiCall::from_args(ctl_argv);
+            match cli {
+                MultiCall::Ctl(_) => {}
+                MultiCall::D(cmd) => panic!(cmd),
+            };
+        }
+    }
+
+    #[test]
+    fn test_verbosity() {
+        let default = MultiCall::from_args(vec!["bootupd".to_string(), "daemon".to_string()]);
+        assert_eq!(default.loglevel(), LevelFilter::Warn);
+
+        let info = MultiCall::from_args(vec![
+            "bootupd".to_string(),
+            "daemon".to_string(),
+            "-v".to_string(),
+        ]);
+        assert_eq!(info.loglevel(), LevelFilter::Info);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 //! Bootupd command-line application.
 
-use log::LevelFilter;
 use structopt::clap::crate_name;
 
 /// Binary entrypoint, for both daemon and client logic.
@@ -12,13 +11,14 @@ fn main() {
 /// CLI logic.
 fn run_cli() -> i32 {
     // Parse command-line options.
-    let cli_opts = bootupd::MultiCall::from_args();
+    let args: Vec<_> = std::env::args().collect();
+    let cli_opts = bootupd::MultiCall::from_args(args);
 
     // Setup logging.
     env_logger::Builder::from_default_env()
         .format_timestamp(None)
         .format_module_path(false)
-        .filter(Some(crate_name!()), LevelFilter::Warn)
+        .filter(Some(crate_name!()), cli_opts.loglevel())
         .init();
 
     // Dispatch CLI subcommand.

--- a/systemd/bootupd.service
+++ b/systemd/bootupd.service
@@ -4,7 +4,8 @@ Documentation=https://github.com/coreos/bootupd
 
 [Service]
 Type=notify
-ExecStart=/usr/libexec/bootupd daemon
+Environment=BOOTUPD_VERBOSITY="-v"
+ExecStart=/usr/libexec/bootupd daemon $BOOTUPD_VERBOSITY
 # On general principle
 ProtectHome=yes
 # So we can remount /boot writable


### PR DESCRIPTION
This introduces a new `-v(vv)` flag separately on both `bootupd` and `bootupctl`
to control log verbosity. The default level only shows warnings and
higher priorities.
The service unit sets up the daemon to log info messages too, and
can be overridden via a drop-in.
This also introduces some basic unit-tests on CLI parsing.

/cc @cgwalters 