### PR TITLE
daemon: log and keep going on client errors

### DIFF
--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -15,7 +15,6 @@ Refs:
 
 use anyhow::{bail, Context, Result};
 use fs2::FileExt;
-use nix::sys::socket as nixsocket;
 use openat_ext::OpenatDirExt;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -27,6 +26,7 @@ use std::path::Path;
 mod cli;
 pub use cli::MultiCall;
 mod component;
+mod daemon;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 mod efi;
 mod filetree;
@@ -254,76 +254,6 @@ fn status() -> Result<Status> {
         );
     }
     Ok(ret)
-}
-
-fn daemon_process_one(client: &mut ipc::AuthenticatedClient) -> Result<()> {
-    let mut buf = [0u8; ipc::MSGSIZE];
-    loop {
-        let n = nixsocket::recv(client.fd, &mut buf, nixsocket::MsgFlags::MSG_CMSG_CLOEXEC)?;
-        let buf = &buf[0..n];
-        if buf.is_empty() {
-            println!("Client disconnected");
-            break;
-        }
-
-        let msg = bincode::deserialize(&buf)?;
-        let r = match msg {
-            ClientRequest::Update { component } => {
-                println!("Processing update");
-                bincode::serialize(&match update(component.as_str()) {
-                    Ok(v) => ipc::DaemonToClientReply::Success::<ComponentUpdateResult>(v),
-                    Err(e) => ipc::DaemonToClientReply::Failure(format!("{:#}", e)),
-                })?
-            }
-            ClientRequest::Validate { component } => {
-                println!("Processing validate");
-                bincode::serialize(&match validate(component.as_str()) {
-                    Ok(v) => ipc::DaemonToClientReply::Success::<ValidationResult>(v),
-                    Err(e) => ipc::DaemonToClientReply::Failure(format!("{:#}", e)),
-                })?
-            }
-            ClientRequest::Status => {
-                println!("Processing status");
-                bincode::serialize(&match status() {
-                    Ok(v) => ipc::DaemonToClientReply::Success::<Status>(v),
-                    Err(e) => ipc::DaemonToClientReply::Failure(format!("{:#}", e)),
-                })?
-            }
-        };
-        let written = nixsocket::send(client.fd, &r, nixsocket::MsgFlags::MSG_CMSG_CLOEXEC)?;
-        if written != r.len() {
-            bail!("Wrote {} bytes to client, expected {}", written, r.len());
-        }
-    }
-    Ok(())
-}
-
-fn daemon() -> Result<()> {
-    use libsystemd::daemon::{self, NotifyState};
-    use std::os::unix::io::IntoRawFd;
-    if !daemon::booted() {
-        bail!("Not running systemd")
-    }
-    let mut fds = libsystemd::activation::receive_descriptors(true)
-        .map_err(|e| anyhow::anyhow!("Failed to receieve systemd descriptors: {}", e))?;
-    let srvsock_fd = if let Some(fd) = fds.pop() {
-        fd
-    } else {
-        bail!("No fd passed from systemd");
-    };
-    let srvsock_fd = srvsock_fd.into_raw_fd();
-    let sent = daemon::notify(true, &[NotifyState::Ready]).expect("notify failed");
-    if !sent {
-        bail!("Failed to notify systemd");
-    }
-    loop {
-        let client = ipc::UnauthenticatedClient::new(nixsocket::accept4(
-            srvsock_fd,
-            nixsocket::SockFlag::SOCK_CLOEXEC,
-        )?);
-        let mut client = client.authenticate()?;
-        daemon_process_one(&mut client)?;
-    }
 }
 
 fn print_status(status: &Status) {

--- a/src/cli/bootupd.rs
+++ b/src/cli/bootupd.rs
@@ -32,7 +32,7 @@ impl DCommand {
     /// Run CLI application.
     pub fn run(self) -> Result<()> {
         match self {
-            DCommand::Daemon => crate::daemon(),
+            DCommand::Daemon => crate::daemon::daemon(),
             DCommand::Install(opts) => Self::run_install(opts),
             DCommand::GenerateUpdateMetadata(opts) => Self::run_generate_meta(opts),
         }

--- a/src/cli/bootupd.rs
+++ b/src/cli/bootupd.rs
@@ -32,7 +32,7 @@ impl DCommand {
     /// Run CLI application.
     pub fn run(self) -> Result<()> {
         match self {
-            DCommand::Daemon => crate::daemon::daemon(),
+            DCommand::Daemon => crate::daemon::run_coreloop(),
             DCommand::Install(opts) => Self::run_install(opts),
             DCommand::GenerateUpdateMetadata(opts) => Self::run_generate_meta(opts),
         }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1,0 +1,78 @@
+//! Daemon logic.
+
+use crate::ipc;
+use anyhow::{bail, Result};
+use nix::sys::socket as nixsocket;
+
+pub fn daemon() -> Result<()> {
+    use libsystemd::daemon::{self, NotifyState};
+    use std::os::unix::io::IntoRawFd;
+
+    if !daemon::booted() {
+        bail!("Not running systemd")
+    }
+    let mut fds = libsystemd::activation::receive_descriptors(true)
+        .map_err(|e| anyhow::anyhow!("Failed to receieve systemd descriptors: {}", e))?;
+    let srvsock_fd = if let Some(fd) = fds.pop() {
+        fd
+    } else {
+        bail!("No fd passed from systemd");
+    };
+    let srvsock_fd = srvsock_fd.into_raw_fd();
+    let sent = daemon::notify(true, &[NotifyState::Ready]).expect("notify failed");
+    if !sent {
+        bail!("Failed to notify systemd");
+    }
+    loop {
+        let client = ipc::UnauthenticatedClient::new(nixsocket::accept4(
+            srvsock_fd,
+            nixsocket::SockFlag::SOCK_CLOEXEC,
+        )?);
+        let mut client = client.authenticate()?;
+        daemon_process_one(&mut client)?;
+    }
+}
+
+fn daemon_process_one(client: &mut ipc::AuthenticatedClient) -> Result<()> {
+    use crate::ClientRequest;
+
+    let mut buf = [0u8; ipc::MSGSIZE];
+    loop {
+        let n = nixsocket::recv(client.fd, &mut buf, nixsocket::MsgFlags::MSG_CMSG_CLOEXEC)?;
+        let buf = &buf[0..n];
+        if buf.is_empty() {
+            println!("Client disconnected");
+            break;
+        }
+
+        let msg = bincode::deserialize(&buf)?;
+        let r = match msg {
+            ClientRequest::Update { component } => {
+                println!("Processing update");
+                bincode::serialize(&match crate::update(component.as_str()) {
+                    Ok(v) => ipc::DaemonToClientReply::Success::<crate::ComponentUpdateResult>(v),
+                    Err(e) => ipc::DaemonToClientReply::Failure(format!("{:#}", e)),
+                })?
+            }
+            ClientRequest::Validate { component } => {
+                println!("Processing validate");
+                bincode::serialize(&match crate::validate(component.as_str()) {
+                    Ok(v) => ipc::DaemonToClientReply::Success::<crate::ValidationResult>(v),
+                    Err(e) => ipc::DaemonToClientReply::Failure(format!("{:#}", e)),
+                })?
+            }
+            ClientRequest::Status => {
+                println!("Processing status");
+                bincode::serialize(&match crate::status() {
+                    Ok(v) => ipc::DaemonToClientReply::Success::<crate::Status>(v),
+                    Err(e) => ipc::DaemonToClientReply::Failure(format!("{:#}", e)),
+                })?
+            }
+        };
+        let written = nixsocket::send(client.fd, &r, nixsocket::MsgFlags::MSG_CMSG_CLOEXEC)?;
+        if written != r.len() {
+            bail!("Wrote {} bytes to client, expected {}", written, r.len());
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
This tweaks daemon core-logic to keep going on client-induced errors,
logging them at "error" level.
It also introduces docstrings and minor reflows to ease casual code navigation.

/cc @cgwalters 