### PR TITLE
filetree: Fix creation of parent directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "openat-ext"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2862a15ef65cac3c516de37ce6f026e0d77ad03d229f471e8294a29a962da1d6"
+checksum = "af1be1e54fbd54bae8b4497ddcc30f97ae57f18fa37fa2f35d48db7b0a8f0b59"
 dependencies = [
  "libc",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ libsystemd = "^0.2"
 log = "^0.4"
 nix = "0.17.0"
 openat = "0.1.19"
-openat-ext = "^0.1.5"
+openat-ext = "^0.1.6"
 openssl = "^0.10"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"


### PR DESCRIPTION
An embarrassing bug where I accidentally intermixed
absolute path handling with fd-relative, and wasn't caught
by either the unit tests or integration tests because the
current directory was writable.

But it was caught by a new test suite which doesn't use
`rpm-ostree usroverlay`.