### PR TITLE
daemon: Exit when done processing requests

### DIFF
--- a/src/cli/bootupd.rs
+++ b/src/cli/bootupd.rs
@@ -57,7 +57,7 @@ impl DCommand {
     /// Run CLI application.
     pub fn run(self) -> Result<()> {
         match self.cmd {
-            DVerb::Daemon => crate::daemon::run_coreloop(),
+            DVerb::Daemon => crate::daemon::run(),
             DVerb::Install(opts) => Self::run_install(opts),
             DVerb::GenerateUpdateMetadata(opts) => Self::run_generate_meta(opts),
         }

--- a/systemd/bootupd.service
+++ b/systemd/bootupd.service
@@ -1,6 +1,11 @@
 [Unit]
 Description=bootloader update daemon
 Documentation=https://github.com/coreos/bootupd
+# Because the daemon currently agressively auto-exits
+# and our test suite runs many requests, let's allow
+# a lot of restarts before failing.
+StartLimitIntervalSec=2s
+StartLimitBurst=10
 
 [Service]
 Type=notify

--- a/tests/kola/test-bootupd
+++ b/tests/kola/test-bootupd
@@ -48,6 +48,11 @@ assert_file_has_content_literal out.txt '  Installed: grub2-efi-x64-'
 assert_file_has_content_literal out.txt 'Update: At latest version'
 ok status
 
+# Validate we auto-exited
+sleep 2
+systemctl show -p ActiveState bootupd > out.txt
+assert_file_has_content_literal out.txt 'ActiveState=inactive'
+
 bootupctl validate | tee out.txt
 ok validate
 


### PR DESCRIPTION
There's no reason to sit there taking up RAM just because
someone did `bootupctl status`.  Properly implementing
exit-on-idle really requires an event loop (e.g. `tokio`)
but that'd be a large change.

For now let's just exit when a client disconnects.  However,
this quickly broke the test suite which does a lot of
commands in a row.

Tweak the systemd unit to allow more restarts, and also
add a few strategic sleeps.

Closes: https://github.com/coreos/bootupd/issues/43