### PR TITLE
Parse and print CoreOS aleph version

### DIFF
--- a/src/coreos.rs
+++ b/src/coreos.rs
@@ -1,0 +1,59 @@
+//! Bits specific to Fedora CoreOS (and derivatives).
+
+/*
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use anyhow::Result;
+use openat_ext::OpenatDirExt;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, Ord, PartialOrd, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+/// See https://github.com/coreos/fedora-coreos-tracker/blob/66d7d00bedd9d5eabc7287b9577f443dcefb7c04/internals/README-internals.md#aleph-version
+pub(crate) struct Aleph {
+    pub(crate) build: String,
+    #[serde(rename = "ref")]
+    pub(crate) ostree_ref: String,
+    pub(crate) ostree_commit: String,
+    pub(crate) imgid: String,
+}
+
+/// Path to the file, see above
+const ALEPH_PATH: &str = "/sysroot/.coreos-aleph-version.json";
+
+pub(crate) fn get_aleph_version() -> Result<Option<Aleph>> {
+    let sysroot = openat::Dir::open("/")?;
+    if let Some(statusf) = sysroot.open_file_optional(ALEPH_PATH)? {
+        let bufr = std::io::BufReader::new(statusf);
+        let aleph: Aleph = serde_json::from_reader(bufr)?;
+        Ok(Some(aleph))
+    } else {
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use anyhow::Result;
+
+    #[test]
+    fn test_parse_aleph() -> Result<()> {
+        let alephdata = r##"
+{
+    "build": "32.20201002.dev.2",
+    "ref": "fedora/x86_64/coreos/testing-devel",
+    "ostree-commit": "b2ea6159d6274e1bbbb49aa0ef093eda5d53a75c8a793dbe184f760ed64dc862",
+    "imgid": "fedora-coreos-32.20201002.dev.2-qemu.x86_64.qcow2"
+}"##;
+        let aleph: Aleph = serde_json::from_str(alephdata)?;
+        assert_eq!(
+            aleph.imgid,
+            "fedora-coreos-32.20201002.dev.2-qemu.x86_64.qcow2"
+        );
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ Refs:
 mod bootupd;
 mod cli;
 mod component;
+mod coreos;
 mod daemon;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 mod efi;

--- a/src/model.rs
+++ b/src/model.rs
@@ -88,6 +88,12 @@ pub(crate) struct ComponentStatus {
     pub(crate) updatable: ComponentUpdatable,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum OperatingSystem {
+    CoreOS { aleph_imgid: String },
+}
+
 /// Representation of bootupd's worldview at a point in time.
 /// This is intended to be a stable format that is output by `bootupctl status --json`
 /// and parsed by higher level management tools.  Transitively then
@@ -97,6 +103,8 @@ pub(crate) struct ComponentStatus {
 pub(crate) struct Status {
     /// Maps a component name to status
     pub(crate) components: BTreeMap<String, ComponentStatus>,
+    /// The detected operating system
+    pub(crate) os: Option<OperatingSystem>,
 }
 
 #[cfg(test)]

--- a/tests/kola/test-bootupd
+++ b/tests/kola/test-bootupd
@@ -46,6 +46,7 @@ bootupctl status > out.txt
 assert_file_has_content_literal out.txt 'Component EFI'
 assert_file_has_content_literal out.txt '  Installed: grub2-efi-x64-'
 assert_file_has_content_literal out.txt 'Update: At latest version'
+assert_file_has_content out.txt 'CoreOS aleph image ID: .*-qemu.'$(arch)'.qcow2'
 ok status
 
 # Validate we auto-exited


### PR DESCRIPTION
This is prep for work on "adoption":
https://github.com/coreos/bootupd/issues/38

In order to (as safely as possible) take over management
of a system *not installed via bootupd* we want to gather
as much information as we can.

For example, we can use the imgid as the "version" of the
current bootloader data.