### PR TITLE
cargo: drop library crate, for now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,14 +128,16 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942f72db697d8767c22d46a598e01f2d3b475501ea43d0db4f16d90259182d0b"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
+ "libc",
  "num-integer",
  "num-traits",
  "serde",
  "time",
+ "winapi",
 ]
 
 [[package]]
@@ -302,9 +304,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.77"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
+checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 
 [[package]]
 name = "libsystemd"
@@ -459,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.21"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
@@ -583,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
+checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
 dependencies = [
  "itoa",
  "ryu",
@@ -642,9 +644,9 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
+checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,6 @@ version = "0.1.1"
 authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2018"
 
-[lib]
-name = "bootupd"
-path = "src/bootupd.rs"
-
 [[bin]]
 name = "bootupd"
 path = "src/main.rs"

--- a/src/cli/bootupctl.rs
+++ b/src/cli/bootupctl.rs
@@ -1,4 +1,6 @@
+use crate::bootupd;
 use crate::ipc::ClientToDaemonConnection;
+use crate::model::Status;
 use anyhow::Result;
 use log::LevelFilter;
 use structopt::clap::AppSettings;
@@ -80,13 +82,13 @@ impl CtlCommand {
         let mut client = ClientToDaemonConnection::new();
         client.connect()?;
 
-        let r: crate::Status = client.send(&crate::ClientRequest::Status)?;
+        let r: Status = client.send(&bootupd::ClientRequest::Status)?;
         if opts.json {
             let stdout = std::io::stdout();
             let mut stdout = stdout.lock();
             serde_json::to_writer_pretty(&mut stdout, &r)?;
         } else {
-            crate::print_status(&r);
+            bootupd::print_status(&r);
         }
 
         client.shutdown()?;
@@ -98,7 +100,7 @@ impl CtlCommand {
         let mut client = ClientToDaemonConnection::new();
         client.connect()?;
 
-        crate::client_run_update(&mut client)?;
+        bootupd::client_run_update(&mut client)?;
 
         client.shutdown()?;
         Ok(())
@@ -108,7 +110,7 @@ impl CtlCommand {
     fn run_validate() -> Result<()> {
         let mut client = ClientToDaemonConnection::new();
         client.connect()?;
-        crate::client_run_validate(&mut client)?;
+        bootupd::client_run_validate(&mut client)?;
         client.shutdown()?;
         Ok(())
     }

--- a/src/cli/bootupd.rs
+++ b/src/cli/bootupd.rs
@@ -1,3 +1,4 @@
+use crate::bootupd;
 use anyhow::{Context, Result};
 use log::LevelFilter;
 use structopt::StructOpt;
@@ -65,13 +66,14 @@ impl DCommand {
 
     /// Runner for `generate-install-metadata` verb.
     pub(crate) fn run_generate_meta(opts: GenerateOpts) -> Result<()> {
-        crate::generate_update_metadata(&opts.sysroot).context("generating metadata failed")?;
+        bootupd::generate_update_metadata(&opts.sysroot).context("generating metadata failed")?;
         Ok(())
     }
 
     /// Runner for `install` verb.
     pub(crate) fn run_install(opts: InstallOpts) -> Result<()> {
-        crate::install(&opts.src_root, &opts.dest_root).context("boot data installation failed")?;
+        bootupd::install(&opts.src_root, &opts.dest_root)
+            .context("boot data installation failed")?;
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,30 @@
-//! Bootupd command-line application.
+/*!
+**Boot**loader **upd**ater.
+
+This is an early prototype hidden/not-yet-standardized mechanism
+which just updates EFI for now (x86_64/aarch64 only).
+
+But in the future will hopefully gain some independence from
+ostree and also support e.g. updating the MBR etc.
+
+Refs:
+ * <https://github.com/coreos/fedora-coreos-tracker/issues/510>
+!*/
+
+#![deny(unused_must_use)]
+
+mod bootupd;
+mod cli;
+mod component;
+mod daemon;
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+mod efi;
+mod filetree;
+mod ipc;
+mod model;
+mod ostreeutil;
+mod sha512string;
+mod util;
 
 use structopt::clap::crate_name;
 
@@ -12,7 +38,7 @@ fn main() {
 fn run_cli() -> i32 {
     // Parse command-line options.
     let args: Vec<_> = std::env::args().collect();
-    let cli_opts = bootupd::MultiCall::from_args(args);
+    let cli_opts = cli::MultiCall::from_args(args);
 
     // Setup logging.
     env_logger::Builder::from_default_env()


### PR DESCRIPTION
This removes the current library/binary crate split, leaving
only the application in place.
The original idea was to add the logic as a vendored library into
rpm-ostree for an emergency fix. However the urgency dropped and
this now lives as a self-standing application.
We may or may not consider re-adding it later on, but only for the
interop parts (paths, JSON, etc).

/cc @cgwalters 