### PR TITLE
status: Fix indentation of CoreOS aleph image ID

### DIFF
--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -270,7 +270,7 @@ pub(crate) fn print_status(status: &Status) {
     if let Some(ref os) = status.os {
         match os {
             OperatingSystem::CoreOS { aleph_imgid } => {
-                println!("  CoreOS aleph image ID: {}", aleph_imgid);
+                println!("CoreOS aleph image ID: {}", aleph_imgid);
             }
         }
     }

--- a/tests/kola/test-bootupd
+++ b/tests/kola/test-bootupd
@@ -46,7 +46,7 @@ bootupctl status > out.txt
 assert_file_has_content_literal out.txt 'Component EFI'
 assert_file_has_content_literal out.txt '  Installed: grub2-efi-x64-'
 assert_file_has_content_literal out.txt 'Update: At latest version'
-assert_file_has_content out.txt 'CoreOS aleph image ID: .*-qemu.'$(arch)'.qcow2'
+assert_file_has_content out.txt '^CoreOS aleph image ID: .*-qemu.'$(arch)'.qcow2'
 ok status
 
 # Validate we auto-exited


### PR DESCRIPTION
If it's indented it looks like it's part of the EFI component.