### PR TITLE
coreos: Add timestamp to aleph version

### DIFF
--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -238,7 +238,7 @@ pub(crate) fn status() -> Result<Status> {
     }
     if let Some(coreos_aleph) = coreos::get_aleph_version()? {
         ret.os = Some(OperatingSystem::CoreOS {
-            aleph_imgid: coreos_aleph.imgid,
+            aleph_imgid: coreos_aleph.aleph.imgid,
         })
     }
     Ok(ret)


### PR DESCRIPTION
Prep for adoption; we use the aleph as a `ContentMetadata`
which wants both a timestamp and a version string.