### PR TITLE
 Drop operating system from status, print client side

### DIFF
--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -1,9 +1,7 @@
 use crate::component::{Component, ValidationResult};
 use crate::coreos;
 use crate::efi;
-use crate::model::{
-    ComponentStatus, ComponentUpdatable, ContentMetadata, OperatingSystem, SavedState, Status,
-};
+use crate::model::{ComponentStatus, ComponentUpdatable, ContentMetadata, SavedState, Status};
 use crate::{component, ipc};
 use anyhow::{anyhow, bail, Context, Result};
 use fs2::FileExt;
@@ -247,17 +245,13 @@ pub(crate) fn status() -> Result<Status> {
     } else {
         log::trace!("No saved state");
     }
+
     log::trace!("Remaining known components: {}", known_components.len());
 
-    if let Some(coreos_aleph) = coreos::get_aleph_version()? {
-        ret.os = Some(OperatingSystem::CoreOS {
-            aleph_imgid: coreos_aleph.aleph.imgid,
-        })
-    }
     Ok(ret)
 }
 
-pub(crate) fn print_status(status: &Status) {
+pub(crate) fn print_status(status: &Status) -> Result<()> {
     if status.components.is_empty() {
         println!("No components installed.");
     }
@@ -283,12 +277,8 @@ pub(crate) fn print_status(status: &Status) {
         println!("  Update: {}", msg);
     }
 
-    if let Some(ref os) = status.os {
-        match os {
-            OperatingSystem::CoreOS { aleph_imgid } => {
-                println!("CoreOS aleph image ID: {}", aleph_imgid);
-            }
-        }
+    if let Some(coreos_aleph) = coreos::get_aleph_version()? {
+        println!("CoreOS aleph image ID: {}", coreos_aleph.aleph.imgid);
     }
 
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
@@ -300,6 +290,8 @@ pub(crate) fn print_status(status: &Status) {
         };
         println!("Boot method: {}", boot_method);
     }
+
+    Ok(())
 }
 
 /// Checks that the user has provided an environment variable to signal

--- a/src/cli/bootupctl.rs
+++ b/src/cli/bootupctl.rs
@@ -88,7 +88,7 @@ impl CtlCommand {
             let mut stdout = stdout.lock();
             serde_json::to_writer_pretty(&mut stdout, &r)?;
         } else {
-            bootupd::print_status(&r);
+            bootupd::print_status(&r)?;
         }
 
         client.shutdown()?;

--- a/src/model.rs
+++ b/src/model.rs
@@ -91,12 +91,6 @@ pub(crate) struct ComponentStatus {
     pub(crate) updatable: ComponentUpdatable,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "kebab-case")]
-pub(crate) enum OperatingSystem {
-    CoreOS { aleph_imgid: String },
-}
-
 /// Representation of bootupd's worldview at a point in time.
 /// This is intended to be a stable format that is output by `bootupctl status --json`
 /// and parsed by higher level management tools.  Transitively then
@@ -107,8 +101,6 @@ pub(crate) enum OperatingSystem {
 pub(crate) struct Status {
     /// Maps a component name to status
     pub(crate) components: BTreeMap<String, ComponentStatus>,
-    /// The detected operating system
-    pub(crate) os: Option<OperatingSystem>,
 }
 
 #[cfg(test)]

--- a/tests/fixtures/example-status-v0.json
+++ b/tests/fixtures/example-status-v0.json
@@ -13,10 +13,5 @@
       "updatable": "at-latest-version",
       "adopted-from": null
     }
-  },
-  "os": {
-    "core-o-s": {
-      "aleph_imgid": "fedora-coreos-32.20201007.dev.0-qemu.x86_64.qcow2"
-    }
   }
 }


### PR DESCRIPTION
For now let's address concerns over how we represent
the operating system by dropping them from the status
JSON.  Instead detect CoreOS specifically client side
too and print the aleph there.


