### PR TITLE
model: Deny unknown saved state fields

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -42,6 +42,7 @@ pub(crate) struct InstalledContent {
 /// Will be serialized into /boot/bootupd-state.json
 #[derive(Serialize, Deserialize, Default, Debug)]
 #[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields)]
 pub(crate) struct SavedState {
     /// Maps a component name to its currently installed version
     pub(crate) installed: BTreeMap<String, InstalledContent>,


### PR DESCRIPTION
This is a big hammer and eventually what we'll really need
to do is introduce versioning or compatibility flags.

That said, for now it's better to ensure we're not reading
anything unexpected.

And in a scenario where bootupd is downgraded, it's not
a really big deal because it just means you can't update
the bootloader - which you probably don't want to do
if you're downgrading the operating system anyways.