### PR TITLE
Drop requirement for BOOTUPD_ACCEPT_PREVIEW=1

### DIFF
--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -331,22 +331,7 @@ pub(crate) fn print_status(status: &Status) -> Result<()> {
     Ok(())
 }
 
-/// Checks that the user has provided an environment variable to signal
-/// acceptance of our alpha state - use this when performing write operations.
-fn validate_preview_env() -> Result<()> {
-    let v = "BOOTUPD_ACCEPT_PREVIEW";
-    if std::env::var_os(v).is_none() {
-        Err(anyhow::anyhow!(
-            "bootupd is currently alpha; set {}=1 in environment to continue",
-            v
-        ))
-    } else {
-        Ok(())
-    }
-}
-
 pub(crate) fn client_run_update(c: &mut ipc::ClientToDaemonConnection) -> Result<()> {
-    validate_preview_env()?;
     let status: Status = c.send(&ClientRequest::Status)?;
     if status.components.is_empty() {
         println!("No components installed.");
@@ -392,7 +377,6 @@ pub(crate) fn client_run_update(c: &mut ipc::ClientToDaemonConnection) -> Result
 }
 
 pub(crate) fn client_run_adopt_and_update(c: &mut ipc::ClientToDaemonConnection) -> Result<()> {
-    validate_preview_env()?;
     let status: Status = c.send(&ClientRequest::Status)?;
     if status.adoptable.is_empty() {
         println!("No components are adoptable.");

--- a/tests/e2e-adopt/e2e-adopt-in-vm.sh
+++ b/tests/e2e-adopt/e2e-adopt-in-vm.sh
@@ -12,8 +12,6 @@ echo "Starting $0"
 
 enable_bootupd() {
     systemctl start bootupd.socket
-    # For now
-    export BOOTUPD_ACCEPT_PREVIEW=1
 }
 
 current_commit=$(rpm-ostree status --json | jq -r .deployments[0].checksum)

--- a/tests/e2e-update/e2e-update-in-vm.sh
+++ b/tests/e2e-update/e2e-update-in-vm.sh
@@ -49,8 +49,6 @@ if ! test -n "${TARGET_GRUB_PKG}"; then
 fi
 
 systemctl start bootupd.socket
-# For now
-export BOOTUPD_ACCEPT_PREVIEW=1
 
 bootupctl validate
 ok validate

--- a/tests/kola/test-bootupd
+++ b/tests/kola/test-bootupd
@@ -19,9 +19,6 @@ function cleanup () {
   fi
 }
 
-# For now
-export BOOTUPD_ACCEPT_PREVIEW=1
-
 bootefidir=/boot/efi/EFI
 bootupdir=/usr/lib/bootupd/updates
 efiupdir=${bootupdir}/EFI
@@ -90,11 +87,6 @@ ok update avail
 bootupctl status --json > status.json
 jq -r '.components.EFI.installed.version' < status.json > installed.txt
 assert_file_has_content installed.txt '^grub2-efi-x64'
-
-if env -u BOOTUPD_ACCEPT_PREVIEW bootupctl update; then
-  fatal "Ran without BOOTUPD_ACCEPT_PREVIEW"
-fi
-ok required env
 
 bootupctl update | tee out.txt
 assert_file_has_content out.txt 'Updated EFI: grub2-efi-x64.*,test'


### PR DESCRIPTION
I'm increasingly confident in our testing, so let's
drop the requirement to set the environment variable.