### PR TITLE
main: Fix sysroot lock target for install

### DIFF
--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -39,7 +39,7 @@ pub(crate) fn install(source_root: &str, dest_root: &str) -> Result<()> {
     }
 
     let mut state_guard =
-        SavedState::acquire_write_lock(source_root).context("failed to acquire write lock")?;
+        SavedState::acquire_write_lock(dest_root).context("failed to acquire write lock")?;
     let mut sysroot = openat::Dir::open(dest_root)?;
     state_guard
         .update_state(&mut sysroot, &state)


### PR DESCRIPTION
Depends https://github.com/coreos/fedora-coreos-config/pull/707
Followup fix for https://github.com/coreos/bootupd/pull/84#issuecomment-709414840