### PR TITLE
component: Add error prefixing

### DIFF
--- a/src/component.rs
+++ b/src/component.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::Write as IoWrite;
@@ -107,6 +107,7 @@ pub(crate) fn get_component_update(
         return Ok(None);
     }
     let mut f = std::io::BufReader::new(File::open(&metap)?);
-    let u = serde_json::from_reader(&mut f)?;
+    let u =
+        serde_json::from_reader(&mut f).with_context(|| format!("failed to parse {:?}", metap))?;
     Ok(Some(u))
 }


### PR DESCRIPTION
I think this is the error we're seeing in
https://github.com/coreos/fedora-coreos-config/pull/711#issuecomment-716780537
But let's add some error prefixing to be sure for the future.