### PR TITLE
Add some more error-prefixing

### DIFF
--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -34,7 +34,9 @@ pub(crate) fn install(source_root: &str, dest_root: &str) -> Result<()> {
 
     let mut state = SavedState::default();
     for component in components.values() {
-        let meta = component.install(source_root, dest_root)?;
+        let meta = component
+            .install(source_root, dest_root)
+            .with_context(|| format!("installing component {}", component.name()))?;
         state.installed.insert(component.name().into(), meta);
     }
 

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -101,11 +101,13 @@ impl Component for EFI {
             anyhow::bail!("No update metadata for component {} found", self.name());
         };
         let srcdir = component_updatedir(src_root, self);
-        let srcd = openat::Dir::open(&srcdir)?;
+        let srcd = openat::Dir::open(&srcdir)
+            .with_context(|| format!("opening src dir {}", srcdir.display()))?;
         let ft = crate::filetree::FileTree::new_from_dir(&srcd)?;
         let destdir = Path::new(dest_root).join(MOUNT_PATH);
         {
-            let destd = openat::Dir::open(&destdir)?;
+            let destd = openat::Dir::open(&destdir)
+                .with_context(|| format!("opening dest dir {}", destdir.display()))?;
             validate_esp(&destd)?;
         }
         let r = std::process::Command::new("cp")


### PR DESCRIPTION
I think we're hitting issues in CI in this path right now.
See: https://github.com/coreos/fedora-coreos-config/pull/711.