### PR TITLE
Parse old "0.1" format installed state format

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod efi;
 mod filetree;
 mod ipc;
 mod model;
+mod model_legacy;
 mod ostreeutil;
 mod sha512string;
 mod util;

--- a/src/model_legacy.rs
+++ b/src/model_legacy.rs
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Implementation of the original bootupd data format, which is the same
+//! as the current one except that the date is defined to be in UTC.
+
+use crate::model::ContentMetadata as NewContentMetadata;
+use crate::model::InstalledContent as NewInstalledContent;
+use crate::model::SavedState as NewSavedState;
+use chrono::prelude::*;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct ContentMetadata01 {
+    /// The timestamp, which is used to determine update availability
+    pub(crate) timestamp: NaiveDateTime,
+    /// Human readable version number, like ostree it is not ever parsed, just displayed
+    pub(crate) version: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct InstalledContent01 {
+    /// Associated metadata
+    pub(crate) meta: ContentMetadata01,
+    /// File tree
+    pub(crate) filetree: Option<crate::filetree::FileTree>,
+}
+
+/// Will be serialized into /boot/bootupd-state.json
+#[derive(Serialize, Deserialize, Default, Debug)]
+#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields)]
+pub(crate) struct SavedState01 {
+    /// Maps a component name to its currently installed version
+    pub(crate) installed: BTreeMap<String, InstalledContent01>,
+    /// Maps a component name to an in progress update
+    pub(crate) pending: Option<BTreeMap<String, ContentMetadata01>>,
+}
+
+impl ContentMetadata01 {
+    pub(crate) fn upconvert(self) -> NewContentMetadata {
+        let timestamp = DateTime::<Utc>::from_utc(self.timestamp, Utc);
+        NewContentMetadata {
+            timestamp,
+            version: self.version,
+        }
+    }
+}
+
+impl InstalledContent01 {
+    pub(crate) fn upconvert(self) -> NewInstalledContent {
+        NewInstalledContent {
+            meta: self.meta.upconvert(),
+            filetree: self.filetree,
+            adopted_from: None,
+        }
+    }
+}
+
+impl SavedState01 {
+    pub(crate) fn upconvert(self) -> NewSavedState {
+        let mut r: NewSavedState = Default::default();
+        for (k, v) in self.installed {
+            r.installed.insert(k, v.upconvert());
+        }
+        r
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use anyhow::Result;
+
+    /// Validate we're not breaking the serialized format of `bootupctl status --json`
+    #[test]
+    fn test_deserialize_status() -> Result<()> {
+        let data = include_str!("../tests/fixtures/example-state-v0-legacy.json");
+        let state: SavedState01 = serde_json::from_str(data)?;
+        let efi = state.installed.get("EFI").expect("EFI");
+        assert_eq!(
+            efi.meta.version,
+            "grub2-efi-x64-1:2.04-23.fc32.x86_64,shim-x64-15-8.x86_64"
+        );
+        let state: NewSavedState = state.upconvert();
+        let efi = state.installed.get("EFI").expect("EFI");
+        let t = chrono::DateTime::parse_from_rfc3339("2020-09-15T13:01:21Z")?;
+        assert_eq!(t, efi.meta.timestamp);
+        assert_eq!(
+            efi.meta.version,
+            "grub2-efi-x64-1:2.04-23.fc32.x86_64,shim-x64-15-8.x86_64"
+        );
+        Ok(())
+    }
+}

--- a/tests/fixtures/example-state-v0-legacy.json
+++ b/tests/fixtures/example-state-v0-legacy.json
@@ -1,0 +1,48 @@
+{
+  "installed": {
+    "EFI": {
+      "meta": {
+        "timestamp": "2020-09-15T13:01:21",
+        "version": "grub2-efi-x64-1:2.04-23.fc32.x86_64,shim-x64-15-8.x86_64"
+      },
+      "filetree": {
+        "timestamp": "1970-01-01T00:00:00",
+        "children": {
+          "BOOT/BOOTX64.EFI": {
+            "size": 1210776,
+            "sha512": "sha512:52e08b6e1686b19fea9e8f8d8ca51d22bba252467ceaf6db6ead8dd2dca4a0b0b02e547e50ddf1cdee225b8785f8514f6baa846bdf1ea0bf994e772daf70f2c3"
+          },
+          "BOOT/fbx64.efi": {
+            "size": 357248,
+            "sha512": "sha512:81fed5039bdd2bc53a203a1eaf56c6a6c9a95aa7ac88f037718a342205d83550f409741c8ef86b481f55ea7188ce0d661742548596f92ef97ba2a1695bc4caae"
+          },
+          "fedora/BOOTX64.CSV": {
+            "size": 110,
+            "sha512": "sha512:0c29b8ae73171ef683ba690069c1bae711e130a084a81169af33a83dfbae4e07d909c2482dbe89a96ab26e171f17c53f1de8cb13d558bc1535412ff8accf253f"
+          },
+          "fedora/grubx64.efi": {
+            "size": 2528520,
+            "sha512": "sha512:b35a6317658d07844d6bf0f96c35f2df90342b8b13a329b4429ac892351ff74fc794a97bc3d3e2d79bef4c234b49a8dd5147b71a3376f24bc956130994e9961c"
+          },
+          "fedora/mmx64.efi": {
+            "size": 1159560,
+            "sha512": "sha512:f83ea67756cfcc3ec4eb1c83104c719ba08e66abfadb94b4bd75891e237c448bbec0fdb5bd42826e291ccc3dee559af424900b3d642a7d11c5bc9f117718837a"
+          },
+          "fedora/shim.efi": {
+            "size": 1210776,
+            "sha512": "sha512:52e08b6e1686b19fea9e8f8d8ca51d22bba252467ceaf6db6ead8dd2dca4a0b0b02e547e50ddf1cdee225b8785f8514f6baa846bdf1ea0bf994e772daf70f2c3"
+          },
+          "fedora/shimx64-fedora.efi": {
+            "size": 1204496,
+            "sha512": "sha512:dc3656b90c0d1767365bea462cc94a2a3044899f510bd61a9a7ae1a9ca586e3d6189592b1ba1ee859f45614421297fa2f5353328caa615f51da5aed9ecfbf29c"
+          },
+          "fedora/shimx64.efi": {
+            "size": 1210776,
+            "sha512": "sha512:52e08b6e1686b19fea9e8f8d8ca51d22bba252467ceaf6db6ead8dd2dca4a0b0b02e547e50ddf1cdee225b8785f8514f6baa846bdf1ea0bf994e772daf70f2c3"
+          }
+        }
+      }
+    }
+  },
+  "pending": null
+}


### PR DESCRIPTION
Since bootupd 0.1.1 shipped in FCOS stable
we need to support updating it, as well as
"pre-bootupd" systems and bootupd 0.2 systems.

I tested this manually; not yet adding an e2e yet for
this because our test suite is already really
expensive and the unit test covers most of it.

Closes: https://github.com/coreos/bootupd/issues/91