### PR TITLE
Release 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "bootupd"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bootupd"
 description = "Bootloader updater"
 license = "Apache-2.0"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2018"
 


### PR DESCRIPTION
```
$ git shortlog v0.2.0..
Colin Walters (7):
      Rework sysroot/statefile locking
      component: Add error prefixing
      Use new openat-ext APIs for writing files
      component: More porting to openat
      Parse old "0.1" format installed state format
      Fix two minor clippy bits
      Release 0.2.1

Jonathan Lebon (1):
      Add some more error-prefixing

Luca BRUNO (1):
      backend/statefile: add a write-lock guard for statefile updates

dependabot[bot] (6):
      build(deps): bump serde_json from 1.0.58 to 1.0.59
      build(deps): bump structopt from 0.3.18 to 0.3.20
      build(deps): bump anyhow from 1.0.32 to 1.0.33
      build(deps): bump nix from 0.17.0 to 0.19.0
      build(deps): bump serde from 1.0.116 to 1.0.117
      build(deps): bump libc from 0.2.79 to 0.2.80

```