### PR TITLE
Add a release-checklist + script

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -1,0 +1,65 @@
+# Release process
+
+The release process follows the usual PR-and-review flow, allowing an external reviewer to have a final check before publishing.
+
+In order to ease downstream packaging of Rust binaries, an archive of vendored dependencies is also provided (only relevant for offline builds).
+
+## Requirements
+
+This guide requires:
+
+ * a web browser (and network connectivity)
+ * `git`
+ * GPG setup and personal key for signing
+ * [git-evtag](https://github.com/cgwalters/git-evtag/)
+ * `cargo` (suggested: latest stable toolchain from [rustup][rustup])
+ * A verified account on crates.io
+ * Write access to this GitHub project
+ * Upload access to this project on GitHub, crates.io
+
+## Release checklist
+
+- Prepare local branch+commit
+  - [ ] `git checkout -b release`
+  - [ ] Bump the version number in `Cargo.toml`.  Usually you just want to bump the patch.
+  - [ ] Run `cargo build` to ensure `Cargo.lock` would be updated
+  - [ ] Commit changes `git commit -a -m 'Release x.y.z'`; include some useful brief changelog.
+
+- Prepare the release
+  - [ ] Run `./ci/prepare-release.sh`
+
+- Validate that `origin` points to the canonical upstream repository and not your fork:
+  `git remote show origin` should not be `github.com/$yourusername/$project` but should
+  be under the organization ownership.  The remote `yourname` should be for your fork.
+
+- Push a PR to create the release:
+  - [ ] `git push --set-upstream origin release`
+  - [ ] open a web browser and create a PR for the branch above
+  - [ ] make sure the resulting PR contains the commit
+  - [ ] in the PR body, write a short changelog with relevant changes since last release
+
+- [ ] get the PR reviewed, approved and merged
+
+- publish the artifacts (tag and crate):
+  - [ ] `git fetch origin && git checkout ${RELEASE_COMMIT}`
+  - [ ] verify `Cargo.toml` has the expected version
+  - [ ] `git-evtag sign v${RELEASE_VER}`
+  - [ ] `git push --tags origin v${RELEASE_VER}`
+  - [ ] `cargo publish`
+
+- publish this release on GitHub:
+  - [ ] find the new tag in the [GitHub tag list](https://github.com/coreos/bootupd/tags) and click the triple dots menu, and create a release for it
+  - [ ] write a short changelog (i.e. re-use the PR content)
+  - [ ] upload `target/${PROJECT}-${RELEASE_VER}-vendor.tar.gz`
+  - [ ] record digests of local artifacts:
+    - `sha256sum target/package/${PROJECT}-${RELEASE_VER}.crate`
+    - `sha256sum target/${PROJECT}-${RELEASE_VER}-vendor.tar.gz`
+  - [ ] publish release
+
+- clean up:
+  - [ ] `git push origin :release`
+  - [ ] `cargo clean`
+  - [ ] `git checkout master`
+
+[rustup]: https://rustup.rs/
+[crates-io]: https://crates.io/

--- a/ci/prepare-release.sh
+++ b/ci/prepare-release.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Prepare a release
+set -euo pipefail
+cargo publish --dry-run
+name=$(cargo read-manifest | jq -r .name)
+version=$(cargo read-manifest | jq -r .version)
+commit=$(git rev-parse HEAD)
+
+# Generate a vendor tarball of sources to attach to a release
+# in order to support offline builds.
+vendor_dest=target/${name}-${version}-vendor.tar.gz
+rm vendor ${vendor_dest} -rf
+cargo vendor
+# Trim off Windows pre-built libraries that make the vendor/ dir much larger
+find vendor/ -name '*.a' -delete
+tar czvf ${vendor_dest}.tmp vendor/
+rm vendor -rf
+mv -Tf ${vendor_dest}{.tmp,}
+
+echo "Prepared ${version} at commit ${commit}"


### PR DESCRIPTION
Taken from the one currently in coreos-installer:
https://github.com/coreos/coreos-installer/blob/master/.github/ISSUE_TEMPLATE/release-checklist.md

But tweaked in various ways:

- I want to continue to use `git-evtag`, will try to teach `cargo-release` about that at some point.
- Rework the vendoring stuff to be a script and run beforehand