### PR TITLE
Add bootupctl status --print-if-available

### DIFF
--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -214,6 +214,24 @@ pub(crate) fn status() -> Result<Status> {
     Ok(ret)
 }
 
+pub(crate) fn print_status_avail(status: &Status) -> Result<()> {
+    let mut avail = Vec::new();
+    for (name, component) in status.components.iter() {
+        if let ComponentUpdatable::Upgradable = component.updatable {
+            avail.push(name.as_str());
+        }
+    }
+    for (name, adoptable) in status.adoptable.iter() {
+        if adoptable.confident {
+            avail.push(name.as_str());
+        }
+    }
+    if !avail.is_empty() {
+        println!("Updates available: {}", avail.join(" "));
+    }
+    Ok(())
+}
+
 pub(crate) fn print_status(status: &Status) -> Result<()> {
     if status.components.is_empty() {
         println!("No components installed.");

--- a/src/cli/bootupctl.rs
+++ b/src/cli/bootupctl.rs
@@ -58,6 +58,12 @@ pub enum CtlBackend {
 
 #[derive(Debug, StructOpt)]
 pub struct StatusOpts {
+    // If there are updates available, output `Updates available: ` to standard output;
+    // otherwise output nothing.  Avoid parsing this, just check whether or not
+    // the output is empty.
+    #[structopt(long)]
+    print_if_available: bool,
+
     // Output JSON
     #[structopt(long)]
     json: bool,
@@ -90,6 +96,8 @@ impl CtlCommand {
             let stdout = std::io::stdout();
             let mut stdout = stdout.lock();
             serde_json::to_writer_pretty(&mut stdout, &r)?;
+        } else if opts.print_if_available {
+            bootupd::print_status_avail(&r)?;
         } else {
             bootupd::print_status(&r)?;
         }

--- a/tests/e2e-update/e2e-update-in-vm.sh
+++ b/tests/e2e-update/e2e-update-in-vm.sh
@@ -60,6 +60,8 @@ assert_not_file_has_content out.txt '  Installed:.*test-bootupd-payload'
 assert_not_file_has_content out.txt '  Installed:.*'"${TARGET_GRUB_PKG}"
 assert_file_has_content out.txt 'Update: Available:.*'"${TARGET_GRUB_PKG}"
 assert_file_has_content out.txt 'Update: Available:.*test-bootupd-payload-1.0'
+bootupctl status --print-if-available > out.txt
+assert_file_has_content_literal 'out.txt' 'Updates available: EFI'
 ok update avail
 
 assert_not_has_file /boot/efi/EFI/fedora/test-bootupd.efi
@@ -68,6 +70,12 @@ bootupctl update | tee out.txt
 assert_file_has_content out.txt "Updated EFI: ${TARGET_GRUB_PKG}.*,test-bootupd-payload-1.0"
 
 assert_file_has_content /boot/efi/EFI/fedora/test-bootupd.efi test-payload
+
+bootupctl status --print-if-available > out.txt
+if test -s out.txt; then
+    fatal "Found available updates: $(cat out.txt)"
+fi
+ok update not avail
 
 tap_finish
 touch /run/testtmp/success


### PR DESCRIPTION
This is a middle ground between:

1) Parse arbitrary text output from `bootupctl status`; this could
   change at any time.
2) Parse JSON from `bootupctl status --json`; parsing this requires
   knowlege of bootupd and the JSON format still isn't 100% fixed
   in stone either.

Projects like https://github.com/openshift/machine-config-operator/
will basically want a flow that just allows them to check for
outstanding updates and apply them one node at a time.