### PR TITLE
status: Fix docstrings

### DIFF
--- a/src/cli/bootupctl.rs
+++ b/src/cli/bootupctl.rs
@@ -58,13 +58,13 @@ pub enum CtlBackend {
 
 #[derive(Debug, StructOpt)]
 pub struct StatusOpts {
-    // If there are updates available, output `Updates available: ` to standard output;
-    // otherwise output nothing.  Avoid parsing this, just check whether or not
-    // the output is empty.
+    /// If there are updates available, output `Updates available: ` to standard output;
+    /// otherwise output nothing.  Avoid parsing this, just check whether or not
+    /// the output is empty.
     #[structopt(long)]
     print_if_available: bool,
 
-    // Output JSON
+    /// Output JSON
     #[structopt(long)]
     json: bool,
 }


### PR DESCRIPTION
We need triple `///` to show in `bootupctl status --help`.