### PR TITLE
Release 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "bootupd"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bootupd"
 description = "Bootloader updater"
 license = "Apache-2.0"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2018"
 


### PR DESCRIPTION
Mainly internal cleanups, plus support for a read-only `/boot`
and `/boot/efi`.