### PR TITLE
Release 0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "bootupd"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bootupd"
 description = "Bootloader updater"
 license = "Apache-2.0"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2018"
 


### PR DESCRIPTION
This adds support for having the ESP not be mounted by
default, which we are going to do in Fedora CoreOS at least.