### PR TITLE
doc: Add license_finder permitted licenses

### DIFF
--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -1,0 +1,37 @@
+---
+- - :permit
+  - MIT OR Apache-2.0
+  - :who: 
+    :why: 
+    :versions: []
+    :when: 2021-02-03 19:31:28.263225624 Z
+- - :permit
+  - Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT
+  - :who: 
+    :why: 
+    :versions: []
+    :when: 2021-02-03 19:31:42.436851761 Z
+- - :permit
+  - MIT
+  - :who: 
+    :why: 
+    :versions: []
+    :when: 2021-02-03 19:31:54.278056841 Z
+- - :permit
+  - Apache 2.0
+  - :who: 
+    :why: 
+    :versions: []
+    :when: 2021-02-03 19:32:08.538863728 Z
+- - :permit
+  - Apache-2.0 OR BSL-1.0
+  - :who: 
+    :why: 
+    :versions: []
+    :when: 2021-02-03 19:32:17.034417362 Z
+- - :permit
+  - New BSD
+  - :who: 
+    :why: 
+    :versions: []
+    :when: 2021-02-03 19:33:02.120977990 Z


### PR DESCRIPTION
https://lists.fedoraproject.org/archives/list/rust@lists.fedoraproject.org/thread/UE4FU27OAHXQ2EOV5OFSXGHELUWZYSJM/
discusses license compliance as something a downstream
distribution should be doing.  Yes.  But also, this is something
that *upstreams* should be doing as part of their CI.

Looking around I found https://github.com/pivotal/LicenseFinder
which looks decent; it handles multiple languages, has
a container image, is FOSS itself etc.

I ran through it for bootupd and this lists the approvals.

The next step here is to validate this in CI.