### PR TITLE
Add and use fn-error-context for more reliable error traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,7 @@ dependencies = [
  "chrono",
  "clap",
  "env_logger",
+ "fn-error-context",
  "fs2",
  "hex",
  "lazy_static",
@@ -214,6 +215,17 @@ name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "fn-error-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac0b92c51c8b8183a0c101a7b2ea5fac11d2f1e01057f91e390284c75d76ef44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "foreign-types"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ bincode = "1.3.2"
 chrono = { version = "0.4.11", features = ["serde"] }
 clap = "~2.33"
 env_logger = "^0.8"
+fn-error-context = "0.1.1"
 fs2 = "0.4.3"
 hex = "0.4.3"
 lazy_static = "1.4.0"

--- a/src/backend/statefile.rs
+++ b/src/backend/statefile.rs
@@ -2,6 +2,7 @@
 
 use crate::model::SavedState;
 use anyhow::{bail, Context, Result};
+use fn_error_context::context;
 use fs2::FileExt;
 use openat_ext::OpenatDirExt;
 use std::fs::File;
@@ -41,6 +42,7 @@ impl SavedState {
     }
 
     /// Load the JSON file containing on-disk state.
+    #[context("Loading saved state")]
     pub(crate) fn load_from_disk(root_path: impl AsRef<Path>) -> Result<Option<SavedState>> {
         let root_path = root_path.as_ref();
         let sysroot = openat::Dir::open(root_path)

--- a/src/component.rs
+++ b/src/component.rs
@@ -5,6 +5,7 @@
  */
 
 use anyhow::{Context, Result};
+use fn_error_context::context;
 use openat_ext::OpenatDirExt;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -109,6 +110,7 @@ pub(crate) fn write_update_metadata(
 }
 
 /// Given a component, return metadata on the available update (if any)
+#[context("Loading update for component {}", component.name())]
 pub(crate) fn get_component_update(
     sysroot: &openat::Dir,
     component: &dyn Component,

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -5,6 +5,7 @@
  */
 
 use anyhow::{bail, Context, Result};
+use fn_error_context::context;
 use nix::sys::socket as nixsocket;
 use serde::{Deserialize, Serialize};
 use std::os::unix::io::RawFd;
@@ -37,6 +38,7 @@ impl ClientToDaemonConnection {
         Self { fd: -1 }
     }
 
+    #[context("connecting to {}", BOOTUPD_SOCKET)]
     pub(crate) fn connect(&mut self) -> Result<()> {
         use nix::sys::uio::IoVec;
         self.fd = nixsocket::socket(
@@ -46,8 +48,7 @@ impl ClientToDaemonConnection {
             None,
         )?;
         let addr = nixsocket::SockAddr::new_unix(BOOTUPD_SOCKET)?;
-        nixsocket::connect(self.fd, &addr)
-            .with_context(|| format!("connecting to {}", BOOTUPD_SOCKET))?;
+        nixsocket::connect(self.fd, &addr)?;
         let creds = libc::ucred {
             pid: nix::unistd::getpid().as_raw(),
             uid: nix::unistd::getuid().as_raw(),


### PR DESCRIPTION
Effectively what we're doing here is creating a human-readable subset
of the stack trace.  This is nicer than having the calling functions
add `with_context()` because it's more verbose (gets duplicative at
each call site), easy to forget, etc.