### PR TITLE
ci: Add Prow-oriented CI flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 fastbuild*.qcow2
 _kola_temp
+.cosa

--- a/ci/prow/Dockerfile
+++ b/ci/prow/Dockerfile
@@ -1,0 +1,19 @@
+FROM registry.ci.openshift.org/coreos/cosa-buildroot:latest as builder
+WORKDIR /src
+COPY . .
+RUN make && make install DESTDIR=/cosa/component-install
+RUN make -C tests/kolainst install DESTDIR=/cosa/component-tests
+# Uncomment this to fake a build to test the code below
+# RUN mkdir -p /cosa/component-install/usr/bin && echo foo > /cosa/component-install/usr/bin/foo
+
+FROM registry.ci.openshift.org/coreos/coreos-assembler:latest
+WORKDIR /srv
+USER root
+# Install our built binaries as overrides for the target build
+COPY --from=builder /cosa/component-install/ /srv/overrides/rootfs/
+# Copy and install tests too
+COPY --from=builder /cosa/component-tests /srv/tmp/component-tests
+# Install tests
+RUN rsync -rlv /srv/tmp/component-tests/ / && rm -rf /srv/tmp/component-tests
+COPY --from=builder /src/ci/prow/fcos-e2e.sh /usr/bin/fcos-e2e
+USER builder

--- a/ci/prow/fcos-e2e.sh
+++ b/ci/prow/fcos-e2e.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# Prow jobs don't support adding emptydir today
+export COSA_SKIP_OVERLAY=1
+gitdir=$(pwd)
+cd $(mktemp -d)
+cosa init --force https://github.com/coreos/fedora-coreos-config/
+cosa fetch
+cosa build
+cosa kola run --qemu-firmware uefi 'ext.bootupd.*'

--- a/tests/kolainst/Makefile
+++ b/tests/kolainst/Makefile
@@ -1,0 +1,6 @@
+all:
+	echo "No build step"
+
+install:
+	mkdir -p $(DESTDIR)/usr/lib/coreos-assembler/tests/kola/
+	rsync -rlv ../kola $(DESTDIR)/usr/lib/coreos-assembler/tests/kola/bootupd


### PR DESCRIPTION
This is copied/adapted from rpm-ostree.  I'm mainly doing
this to prove out adding another GH repo using the nested
virt support.

As part of this, add the "standard" `tests/kolainst` directory
that just copies in our un-installed tests.