### PR TITLE
prow: Fix overrides

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target
+.cosa

--- a/ci/prow/Dockerfile
+++ b/ci/prow/Dockerfile
@@ -8,12 +8,14 @@ RUN make -C tests/kolainst install DESTDIR=/cosa/component-tests
 
 FROM registry.ci.openshift.org/coreos/coreos-assembler:latest
 WORKDIR /srv
-USER root
 # Install our built binaries as overrides for the target build
 COPY --from=builder /cosa/component-install/ /srv/overrides/rootfs/
 # Copy and install tests too
 COPY --from=builder /cosa/component-tests /srv/tmp/component-tests
+# And fix permissions
+RUN sudo chown -R builder: /srv/*
 # Install tests
+USER root
 RUN rsync -rlv /srv/tmp/component-tests/ / && rm -rf /srv/tmp/component-tests
-COPY --from=builder /src/ci/prow/fcos-e2e.sh /usr/bin/fcos-e2e
 USER builder
+COPY --from=builder /src/ci/prow/fcos-e2e.sh /usr/bin/fcos-e2e

--- a/ci/prow/fcos-e2e.sh
+++ b/ci/prow/fcos-e2e.sh
@@ -3,8 +3,6 @@ set -xeuo pipefail
 
 # Prow jobs don't support adding emptydir today
 export COSA_SKIP_OVERLAY=1
-gitdir=$(pwd)
-cd $(mktemp -d)
 cosa init --force https://github.com/coreos/fedora-coreos-config/
 cosa fetch
 cosa build


### PR DESCRIPTION
Not actually testing what you think you are is the worst.

At some point I think I added the `cd $(mktemp -d)` but that loses our overrides.  I'm going to try soon to centralize this as [a multi-stage test](https://docs.ci.openshift.org/docs/architecture/step-registry/) probably.