### PR TITLE
ci: Update to latest buildroot model

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -3,7 +3,7 @@
 stage("Build") {
 parallel build: {
   def n = 5
-  cosaPod(buildroot: true, runAsUser: 0, memory: "2Gi", cpu: "${n}") {
+  buildPod(runAsUser: 0, memory: "2Gi", cpu: "${n}") {
       checkout scm
       stage("Core build") {
         shwrap("""
@@ -23,7 +23,7 @@ parallel build: {
   }
 },
 codestyle: {
-  cosaPod(buildroot: true) {
+  buildPod {
       checkout scm
       shwrap("cargo fmt -- --check")
   }
@@ -32,7 +32,7 @@ codestyle: {
 
 // Build FCOS and do a kola basic run
 // FIXME update to main branch once https://github.com/coreos/fedora-coreos-config/pull/595 merges
-cosaPod(buildroot: true, runAsUser: 0, memory: "3072Mi", cpu: "4") {
+cosaPod(runAsUser: 0, memory: "3072Mi", cpu: "4") {
   stage("Build FCOS") {
     checkout scm
     unstash 'build'

--- a/ci/prow/Dockerfile
+++ b/ci/prow/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/coreos/cosa-buildroot:latest as builder
+FROM quay.io/coreos-assembler/fcos-buildroot:testing-devel as builder
 WORKDIR /src
 COPY . .
 RUN make && make install DESTDIR=/cosa/component-install
@@ -6,7 +6,7 @@ RUN make -C tests/kolainst install DESTDIR=/cosa/component-tests
 # Uncomment this to fake a build to test the code below
 # RUN mkdir -p /cosa/component-install/usr/bin && echo foo > /cosa/component-install/usr/bin/foo
 
-FROM registry.ci.openshift.org/coreos/coreos-assembler:latest
+FROM quay.io/coreos-assembler/coreos-assembler:latest
 WORKDIR /srv
 # Install our built binaries as overrides for the target build
 COPY --from=builder /cosa/component-install/ /srv/overrides/rootfs/


### PR DESCRIPTION
Attempt to update both CCI and Prow.
xref https://github.com/coreos/fedora-coreos-tracker/blob/master/docs/ci-and-builds.md