### PR TITLE
tests/e2e-update: do not rebuild binaries

### DIFF
--- a/tests/e2e-update/e2e-update.sh
+++ b/tests/e2e-update/e2e-update.sh
@@ -80,7 +80,6 @@ if test -z "${e2e_skip_build:-}"; then
     echo "Building starting image"
     rm -f ${overrides}/rpm/*.rpm
     add_override grub2-2.04-22.fc32
-    (cd ${bootupd_git} && runv make && runv make install DESTDIR=${overrides}/rootfs)
     runv cosa build
     prev_image=$(runv cosa meta --image-path qemu)
     create_manifest_fork


### PR DESCRIPTION
Avoid rebuilding the project from source, as binaries have already
been built in previous steps.