### PR TITLE
workflows: bump toolchains; restrict repository access; fix build/lint warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,9 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Minimum supported Rust version (MSRV)
-  ACTION_MSRV_TOOLCHAIN: 1.43.0
+  ACTION_MSRV_TOOLCHAIN: 1.49.0
   # Pinned toolchain for linting
-  ACTION_LINTS_TOOLCHAIN: 1.47.0
+  ACTION_LINTS_TOOLCHAIN: 1.53.0
 
 jobs:
   tests-stable:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,14 @@
 ---
 name: Rust
+
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+
+permissions:
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always

--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -61,7 +61,7 @@ pub(crate) fn get_components() -> Components {
     }
 
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-    insert_component(&mut components, Box::new(efi::EFI::default()));
+    insert_component(&mut components, Box::new(efi::Efi::default()));
 
     // #[cfg(target_arch = "x86_64")]
     // components.push(Box::new(bios::BIOS::new()));

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -58,7 +58,7 @@ mod tests {
             let d_argv = vec!["/usr/bin/bootupd".to_string(), "daemon".to_string()];
             let cli = MultiCall::from_args(d_argv);
             match cli {
-                MultiCall::Ctl(cmd) => panic!(cmd),
+                MultiCall::Ctl(cmd) => panic!("{:?}", cmd),
                 MultiCall::D(_) => {}
             };
         }
@@ -67,7 +67,7 @@ mod tests {
             let cli = MultiCall::from_args(ctl_argv);
             match cli {
                 MultiCall::Ctl(_) => {}
-                MultiCall::D(cmd) => panic!(cmd),
+                MultiCall::D(cmd) => panic!("{:?}", cmd),
             };
         }
         {
@@ -75,7 +75,7 @@ mod tests {
             let cli = MultiCall::from_args(ctl_argv);
             match cli {
                 MultiCall::Ctl(_) => {}
-                MultiCall::D(cmd) => panic!(cmd),
+                MultiCall::D(cmd) => panic!("{:?}", cmd),
             };
         }
     }

--- a/src/component.rs
+++ b/src/component.rs
@@ -12,8 +12,8 @@ use std::path::{Path, PathBuf};
 
 use crate::model::*;
 
-#[serde(rename_all = "kebab-case")]
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "kebab-case")]
 pub(crate) enum ValidationResult {
     Valid,
     Errors(Vec<String>),

--- a/src/component.rs
+++ b/src/component.rs
@@ -70,7 +70,7 @@ pub(crate) trait Component {
 /// Given a component name, create an implementation.
 pub(crate) fn new_from_name(name: &str) -> Result<Box<dyn Component>> {
     let r: Box<dyn Component> = match name {
-        "EFI" => Box::new(crate::efi::EFI::default()),
+        "EFI" => Box::new(crate::efi::Efi::default()),
         _ => anyhow::bail!("No component {}", name),
     };
     Ok(r)

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -36,9 +36,9 @@ lazy_static! {
 }
 
 #[derive(Default)]
-pub(crate) struct EFI {}
+pub(crate) struct Efi {}
 
-impl EFI {
+impl Efi {
     fn esp_path(&self) -> PathBuf {
         Path::new(&*MOUNT_PATH).join("EFI")
     }
@@ -83,7 +83,7 @@ impl EFI {
     }
 }
 
-impl Component for EFI {
+impl Component for Efi {
     fn name(&self) -> &'static str {
         "EFI"
     }


### PR DESCRIPTION
OCP 4.9 has Rust 1.49.