### PR TITLE
Release 0.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "bootupd"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "bootupd"
-version = "0.2.6"
+version = "0.2.7-alpha.0"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bootupd"
 description = "Bootloader updater"
 license = "Apache-2.0"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,12 @@ tempfile = "^3.2"
 [profile.release]
 # We assume we're being delivered via e.g. RPM which supports split debuginfo
 debug = true
+
+[package.metadata.release]
+disable-publish = true
+disable-push = true
+post-release-commit-message = "cargo: development version bump"
+pre-release-commit-message = "cargo: bootupd release {{version}}"
+sign-commit = true
+sign-tag = true
+tag-message = "bootupd {{version}}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bootupd"
 description = "Bootloader updater"
 license = "Apache-2.0"
-version = "0.2.6"
+version = "0.2.7-alpha.0"
 authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2018"
 


### PR DESCRIPTION
Changes:
 * tests/e2e-update: Bump to f34 grub
 * workflows: bump toolchains; restrict repository access; fix build/lint warnings
 * OWNERS: remove
 * git: rename master branch to main
 * ci: Update to latest buildroot model
 * cargo: update all dependencies
 * lockfile: general refresh, update all openssl crates
