### PR TITLE
ci: Don't run basic scenarios

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -65,7 +65,7 @@ cosaPod(runAsUser: 0, memory: "3072Mi", cpu: "4") {
       // The previous e2e leaves things only having built an ostree update
       shwrap("cosa build")
       // bootupd really can't break upgrades for the OS
-      fcosKola(cosaDir: "${env.WORKSPACE}", extraArgs: "ext.*bootupd*", skipUpgrade: true)
+      fcosKola(cosaDir: "${env.WORKSPACE}", extraArgs: "ext.*bootupd*", skipUpgrade: true, skipBasicScenarios: true)
     }
   } finally {
     archiveArtifacts allowEmptyArchive: true, artifacts: 'tmp/console.txt'


### PR DESCRIPTION
We're downgrading to an old grub2 build that is broken, so
we can't actually boot uefi after doing our hacks.

The correct thing here is to change bootupd CI to generate
synthetic RPMs instead of downloading old builds.  Will do that
at some point...