### PR TITLE
Update to Rust 2021; bump MSRV to 1.56.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,8 +12,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  # Minimum supported Rust version (MSRV)
-  ACTION_MSRV_TOOLCHAIN: 1.56.0
   # Pinned toolchain for linting
   ACTION_LINTS_TOOLCHAIN: 1.59.0
 
@@ -54,10 +52,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Detect crate MSRV
+        run: |
+          msrv=$(cargo metadata --format-version 1 --no-deps | \
+              jq -r '.packages | .[].rust_version')
+          echo "Crate MSRV: $msrv"
+          echo "MSRV=$msrv" >> $GITHUB_ENV
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN']  }}
+          toolchain: ${{ env.MSRV }}
           default: true
       - name: cargo build (release)
         run: cargo build --release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   # Minimum supported Rust version (MSRV)
-  ACTION_MSRV_TOOLCHAIN: 1.49.0
+  ACTION_MSRV_TOOLCHAIN: 1.56.0
   # Pinned toolchain for linting
   ACTION_LINTS_TOOLCHAIN: 1.59.0
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ env:
   # Minimum supported Rust version (MSRV)
   ACTION_MSRV_TOOLCHAIN: 1.49.0
   # Pinned toolchain for linting
-  ACTION_LINTS_TOOLCHAIN: 1.57.0
+  ACTION_LINTS_TOOLCHAIN: 1.59.0
 
 jobs:
   tests-stable:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Bootloader updater"
 license = "Apache-2.0"
 version = "0.2.7-alpha.0"
 authors = ["Colin Walters <walters@verbum.org>"]
-edition = "2018"
+edition = "2021"
 
 [[bin]]
 name = "bootupd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ license = "Apache-2.0"
 version = "0.2.7-alpha.0"
 authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2021"
+rust-version = "1.56.0"
 
 [[bin]]
 name = "bootupd"

--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -191,11 +191,7 @@ pub(crate) fn status() -> Result<Status> {
                 .remove(name.as_str())
                 .ok_or_else(|| anyhow!("Unknown component installed: {}", name))?;
             let component = component.as_ref();
-            let interrupted = state
-                .pending
-                .as_ref()
-                .map(|p| p.get(name.as_str()))
-                .flatten();
+            let interrupted = state.pending.as_ref().and_then(|p| p.get(name.as_str()));
             let update = component.query_update(&sysroot)?;
             let updatable = ComponentUpdatable::from_metadata(&ic.meta, update.as_ref());
             let adopted_from = ic.adopted_from.clone();


### PR DESCRIPTION
RHEL 8.6 has a new-enough Rust to allow this.  Also, clap 3.0 needs Rust 1.54.0.