### PR TITLE
cli: reinstate `--version` flag

### DIFF
--- a/src/cli/bootupctl.rs
+++ b/src/cli/bootupctl.rs
@@ -7,7 +7,7 @@ use log::LevelFilter;
 
 /// `bootupctl` sub-commands.
 #[derive(Debug, Parser)]
-#[clap(name = "bootupctl", about = "Bootupd client application")]
+#[clap(name = "bootupctl", about = "Bootupd client application", version)]
 pub struct CtlCommand {
     /// Verbosity level (higher is more verbose).
     #[clap(short = 'v', parse(from_occurrences), global = true)]

--- a/src/cli/bootupd.rs
+++ b/src/cli/bootupd.rs
@@ -5,7 +5,7 @@ use log::LevelFilter;
 
 /// `bootupd` sub-commands.
 #[derive(Debug, Parser)]
-#[clap(name = "bootupd", about = "Bootupd backend commands")]
+#[clap(name = "bootupd", about = "Bootupd backend commands", version)]
 pub struct DCommand {
     /// Verbosity level (higher is more verbose).
     #[clap(short = 'v', parse(from_occurrences), global = true)]


### PR DESCRIPTION
It was lost in the switch to clap 3.1.