### PR TITLE
Bump MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 version = "0.2.7-alpha.0"
 authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2021"
-rust-version = "1.56.0"
+rust-version = "1.58.1"
 
 [[bin]]
 name = "bootupd"


### PR DESCRIPTION
To pick up the latest inline format bits at least.  Matches
other projects in coreos/ GH org.