### PR TITLE
ci: migrate to new directory and method names

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -32,7 +32,7 @@ codestyle: {
 
 // Build FCOS and do a kola basic run
 // FIXME update to main branch once https://github.com/coreos/fedora-coreos-config/pull/595 merges
-cosaPod(runAsUser: 0, memory: "3072Mi", cpu: "4") {
+cosaPod(runAsUser: 0, memory: "4608Mi", cpu: "4") {
   stage("Build FCOS") {
     checkout scm
     unstash 'build'

--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -65,7 +65,7 @@ cosaPod(runAsUser: 0, memory: "3072Mi", cpu: "4") {
       // The previous e2e leaves things only having built an ostree update
       shwrap("cosa build")
       // bootupd really can't break upgrades for the OS
-      fcosKola(cosaDir: "${env.WORKSPACE}", extraArgs: "ext.*bootupd*", skipUpgrade: true, skipBasicScenarios: true)
+      kola(cosaDir: "${env.WORKSPACE}", extraArgs: "ext.*bootupd*", skipUpgrade: true, skipBasicScenarios: true)
     }
   } finally {
     archiveArtifacts allowEmptyArchive: true, artifacts: 'tmp/console.txt'


### PR DESCRIPTION
The previous `fcos*` ones are deprecated.
See: https://github.com/coreos/coreos-ci-lib/pull/122