### PR TITLE
Statically enable bootupd.socket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,5 @@ install: install-units
 	mkdir -p "${DESTDIR}$(PREFIX)/bin" "${DESTDIR}$(LIBEXECDIR)"
 	install -D -t "${DESTDIR}$(LIBEXECDIR)" target/${PROFILE}/bootupd
 	ln -f ${DESTDIR}$(LIBEXECDIR)/bootupd ${DESTDIR}$(PREFIX)/bin/bootupctl
+	install -d "${DESTDIR}$(PREFIX)/lib/systemd/system/multi-user.target.wants"
+	ln -s ../bootupd.socket "${DESTDIR}$(PREFIX)/lib/systemd/system/multi-user.target.wants"

--- a/packaging/rust-bootupd.spec
+++ b/packaging/rust-bootupd.spec
@@ -53,15 +53,6 @@ License:        ASL 2.0
 %install
 %make_install INSTALL="install -p -c"
 
-%post        -n %{crate}
-%systemd_post bootupd.service bootupd.socket
-
-%preun       -n %{crate}
-%systemd_preun bootupd.service bootupd.socket
-
-%postun      -n %{crate}
-%systemd_postun bootupd.service bootupd.socket
-
 %changelog
 * Fri Sep 11 2020 Colin Walters <walters@verbum.org> - 0.1.0-3
 - Initial package

--- a/tests/e2e-update/e2e-update-in-vm.sh
+++ b/tests/e2e-update/e2e-update-in-vm.sh
@@ -48,8 +48,6 @@ if ! test -n "${TARGET_GRUB_PKG}"; then
     fatal "Missing TARGET_GRUB_PKG"
 fi
 
-systemctl start bootupd.socket
-
 bootupctl validate
 ok validate
 

--- a/tests/kola/test-bootupd
+++ b/tests/kola/test-bootupd
@@ -40,8 +40,6 @@ prepare_efi_update() {
   rm -rf ${efiupdir} ${bootupdir}/EFI.json
 }
 
-systemctl start bootupd.socket
-
 bootupctl status > out.txt
 assert_file_has_content_literal out.txt 'Component EFI'
 assert_file_has_content_literal out.txt '  Installed: grub2-efi-x64-'


### PR DESCRIPTION
The fact that we're a systemd unit is mostly an implementation detail so that we get a natural locking mechanism and can reuse systemd sandboxing.

If you have the software installed, we want the socket to be enabled.

Having to work through adding this into presets is just compounding pain for shipping it in multiple places.

Instead, install a static symlink.