### PR TITLE
efi: Reuse existing mountpoint if available

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,8 @@ fn run_cli() -> i32 {
         .filter(Some(crate_name!()), cli_opts.loglevel())
         .init();
 
+    log::trace!("executing cli");
+
     // Dispatch CLI subcommand.
     match cli_opts.run() {
         Ok(_) => libc::EXIT_SUCCESS,


### PR DESCRIPTION
This is an even better fix for https://github.com/coreos/bootupd/issues/367

Basically in coreos-assembler today we're already mounting the ESP, so let's just reuse that existing mount if it's present.  This is also what we want for other systems that pre-mount the ESP.

(At least for now - long term to support redundant ESPs we'll need
 to fully own all of this, but that can come later)