### PR TITLE
bios.rs: implement BIOS (grub)

### DIFF
--- a/src/bios.rs
+++ b/src/bios.rs
@@ -1,0 +1,71 @@
+use std::io::prelude::*;
+use std::path::Path;
+
+use crate::component::*;
+use crate::model::*;
+use anyhow::{bail, Result};
+
+use crate::util;
+
+// grub2-install file path
+pub(crate) const GRUB_BIN: &str = "usr/sbin/grub2-install";
+
+#[derive(Default)]
+pub(crate) struct Bios {}
+
+impl Component for Bios {
+    fn name(&self) -> &'static str {
+        "BIOS"
+    }
+
+    fn install(&self, src_root: &openat::Dir, dest_root: &str) -> Result<InstalledContent> {
+        todo!();
+    }
+
+    fn generate_update_metadata(&self, sysroot_path: &str) -> Result<ContentMetadata> {
+        let grub_install = Path::new(sysroot_path).join(GRUB_BIN);
+        if !grub_install.exists() {
+            bail!("Failed to find {:?}", grub_install);
+        }
+
+        // Query the rpm database and list the package and build times for /usr/sbin/grub2-install
+        let mut rpmout = util::rpm_query(sysroot_path, &grub_install)?;
+        let rpmout = rpmout.output()?;
+        if !rpmout.status.success() {
+            std::io::stderr().write_all(&rpmout.stderr)?;
+            bail!("Failed to invoke rpm -qf");
+        }
+
+        let meta = util::parse_rpm_metadata(rpmout.stdout)?;
+        write_update_metadata(sysroot_path, self, &meta)?;
+        Ok(meta)
+    }
+
+    fn query_adopt(&self) -> Result<Option<Adoptable>> {
+        todo!();
+    }
+
+    fn adopt_update(
+        &self,
+        sysroot: &openat::Dir,
+        update: &ContentMetadata,
+    ) -> Result<InstalledContent> {
+        todo!();
+    }
+
+    fn query_update(&self, sysroot: &openat::Dir) -> Result<Option<ContentMetadata>> {
+        todo!();
+    }
+
+    fn run_update(
+        &self,
+        sysroot: &openat::Dir,
+        current: &InstalledContent,
+    ) -> Result<InstalledContent> {
+        todo!();
+    }
+
+    fn validate(&self, current: &InstalledContent) -> Result<ValidationResult> {
+        todo!();
+    }
+}

--- a/src/bios.rs
+++ b/src/bios.rs
@@ -124,9 +124,10 @@ impl Component for Bios {
     }
 
     fn query_adopt(&self) -> Result<Option<Adoptable>> {
-        todo!();
+        Ok(None)
     }
 
+    #[allow(unused_variables)]
     fn adopt_update(
         &self,
         sysroot: &openat::Dir,

--- a/src/bios.rs
+++ b/src/bios.rs
@@ -153,7 +153,7 @@ impl Component for Bios {
         })
     }
 
-    fn validate(&self, current: &InstalledContent) -> Result<ValidationResult> {
-        todo!();
+    fn validate(&self, _: &InstalledContent) -> Result<ValidationResult> {
+        Ok(ValidationResult::Skip)
     }
 }

--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -1,6 +1,8 @@
+#[cfg(any(target_arch = "x86_64", target_arch = "powerpc64"))]
 use crate::bios;
 use crate::component::{Component, ValidationResult};
 use crate::coreos;
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use crate::efi;
 use crate::model::{ComponentStatus, ComponentUpdatable, ContentMetadata, SavedState, Status};
 use crate::util;

--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -1,3 +1,4 @@
+use crate::bios;
 use crate::component::{Component, ValidationResult};
 use crate::coreos;
 use crate::efi;
@@ -63,8 +64,8 @@ pub(crate) fn get_components() -> Components {
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     insert_component(&mut components, Box::new(efi::Efi::default()));
 
-    // #[cfg(target_arch = "x86_64")]
-    // components.push(Box::new(bios::BIOS::new()));
+    #[cfg(any(target_arch = "x86_64", target_arch = "powerpc64"))]
+    insert_component(&mut components, Box::new(bios::Bios::default()));
 
     components
 }

--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -39,13 +39,13 @@ pub(crate) fn install(source_root: &str, dest_root: &str, device: &str) -> Resul
     for component in components.values() {
         // skip for BIOS if device is empty
         if component.name() == "BIOS" && device.trim().is_empty() {
-                println!(
-                    "Skip installing component {} without target device",
-                    component.name()
-                );
-                continue;
-            }
-    
+            println!(
+                "Skip installing component {} without target device",
+                component.name()
+            );
+            continue;
+        }
+
         let meta = component
             .install(&source_root, dest_root, device)
             .with_context(|| format!("installing component {}", component.name()))?;
@@ -394,6 +394,9 @@ pub(crate) fn client_run_validate(c: &mut ipc::ClientToDaemonConnection) -> Resu
         })? {
             ValidationResult::Valid => {
                 println!("Validated: {}", name);
+            }
+            ValidationResult::Skip => {
+                println!("Skipped: {}", name);
             }
             ValidationResult::Errors(errs) => {
                 for err in errs {

--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -70,6 +70,10 @@ pub(crate) fn get_components() -> Components {
 }
 
 pub(crate) fn generate_update_metadata(sysroot_path: &str) -> Result<()> {
+    // create bootupd update dir which will save component metadata files for both components
+    let updates_dir = Path::new(sysroot_path).join(crate::model::BOOTUPD_UPDATES_DIR);
+    std::fs::create_dir_all(&updates_dir)
+        .with_context(|| format!("Failed to create updates dir {:?}", &updates_dir))?;
     for component in get_components().values() {
         let v = component.generate_update_metadata(sysroot_path)?;
         println!(

--- a/src/cli/bootupd.rs
+++ b/src/cli/bootupd.rs
@@ -47,6 +47,9 @@ pub struct InstallOpts {
     /// Target root
     #[clap(value_parser)]
     dest_root: String,
+    /// Target device, used by bios bootloader installation
+    #[clap(long, value_parser, default_value_t = String::from(""))]
+    device: String,
 }
 
 #[derive(Debug, Parser)]
@@ -74,7 +77,7 @@ impl DCommand {
 
     /// Runner for `install` verb.
     pub(crate) fn run_install(opts: InstallOpts) -> Result<()> {
-        bootupd::install(&opts.src_root, &opts.dest_root)
+        bootupd::install(&opts.src_root, &opts.dest_root, &opts.device)
             .context("boot data installation failed")?;
         Ok(())
     }

--- a/src/component.rs
+++ b/src/component.rs
@@ -71,6 +71,7 @@ pub(crate) trait Component {
 pub(crate) fn new_from_name(name: &str) -> Result<Box<dyn Component>> {
     let r: Box<dyn Component> = match name {
         "EFI" => Box::new(crate::efi::Efi::default()),
+        "BIOS" => Box::new(crate::bios::Bios::default()),
         _ => anyhow::bail!("No component {}", name),
     };
     Ok(r)

--- a/src/component.rs
+++ b/src/component.rs
@@ -44,7 +44,13 @@ pub(crate) trait Component {
     /// of a filesystem root, the component should query the mount point to
     /// determine the block device.
     /// This will be run during a disk image build process.
-    fn install(&self, src_root: &openat::Dir, dest_root: &str) -> Result<InstalledContent>;
+    fn install(
+        &self,
+        src_root: &openat::Dir,
+        dest_root: &str,
+        device: &str,
+    ) -> Result<InstalledContent>;
+        
 
     /// Implementation of `bootupd generate-update-metadata` for a given component.
     /// This expects to be run during an "image update build" process.  For CoreOS

--- a/src/component.rs
+++ b/src/component.rs
@@ -16,6 +16,7 @@ use crate::model::*;
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum ValidationResult {
     Valid,
+    Skip,
     Errors(Vec<String>),
 }
 
@@ -50,7 +51,6 @@ pub(crate) trait Component {
         dest_root: &str,
         device: &str,
     ) -> Result<InstalledContent>;
-        
 
     /// Implementation of `bootupd generate-update-metadata` for a given component.
     /// This expects to be run during an "image update build" process.  For CoreOS

--- a/src/component.rs
+++ b/src/component.rs
@@ -76,7 +76,9 @@ pub(crate) trait Component {
 /// Given a component name, create an implementation.
 pub(crate) fn new_from_name(name: &str) -> Result<Box<dyn Component>> {
     let r: Box<dyn Component> = match name {
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
         "EFI" => Box::new(crate::efi::Efi::default()),
+        #[cfg(any(target_arch = "x86_64", target_arch = "powerpc64"))]
         "BIOS" => Box::new(crate::bios::Bios::default()),
         _ => anyhow::bail!("No component {}", name),
     };
@@ -85,12 +87,14 @@ pub(crate) fn new_from_name(name: &str) -> Result<Box<dyn Component>> {
 
 /// Returns the path to the payload directory for an available update for
 /// a component.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub(crate) fn component_updatedirname(component: &dyn Component) -> PathBuf {
     Path::new(BOOTUPD_UPDATES_DIR).join(component.name())
 }
 
 /// Returns the path to the payload directory for an available update for
 /// a component.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub(crate) fn component_updatedir(sysroot: &str, component: &dyn Component) -> PathBuf {
     Path::new(sysroot).join(component_updatedirname(component))
 }

--- a/src/coreos.rs
+++ b/src/coreos.rs
@@ -24,6 +24,7 @@ pub(crate) struct Aleph {
 
 pub(crate) struct AlephWithTimestamp {
     pub(crate) aleph: Aleph,
+    #[allow(dead_code)]
     pub(crate) ts: chrono::DateTime<Utc>,
 }
 

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -176,7 +176,12 @@ impl Component for Efi {
     }
 
     // TODO: Remove dest_root; it was never actually used
-    fn install(&self, src_root: &openat::Dir, dest_root: &str) -> Result<InstalledContent> {
+    fn install(
+        &self,
+        src_root: &openat::Dir,
+        dest_root: &str,
+        _: &str,
+    ) -> Result<InstalledContent> {
         let meta = if let Some(meta) = get_component_update(src_root, self)? {
             meta
         } else {

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -257,10 +257,6 @@ impl Component for Efi {
 
             // Fork off mv() because on overlayfs one can't rename() a lower level
             // directory today, and this will handle the copy fallback.
-            let parent = dest_efidir
-                .parent()
-                .ok_or_else(|| anyhow::anyhow!("Expected parent directory"))?;
-            std::fs::create_dir_all(&parent)?;
             Command::new("mv").args(&[&efisrc, &dest_efidir]).run()?;
         }
 

--- a/src/filetree.rs
+++ b/src/filetree.rs
@@ -4,23 +4,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use anyhow::{bail, Context, Result};
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use openat_ext::OpenatDirExt;
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use openssl::hash::{Hasher, MessageDigest};
 use serde::{Deserialize, Serialize};
+#[allow(unused_imports)]
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Display;
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use std::os::unix::io::AsRawFd;
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use std::os::unix::process::CommandExt;
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use std::path::Path;
 
 /// The prefix we apply to our temporary files.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub(crate) const TMP_PREFIX: &str = ".btmp.";
 // This module doesn't handle modes right now, because
 // we're only targeting FAT filesystems for UEFI.
 // In FAT there are no unix permission bits, usually
 // they're set by mount options.
 // See also https://github.com/coreos/fedora-coreos-config/commit/8863c2b34095a2ae5eae6fbbd121768a5f592091
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 const DEFAULT_FILE_MODE: u32 = 0o700;
 
 use crate::sha512string::SHA512String;
@@ -69,6 +78,7 @@ impl FileTreeDiff {
 }
 
 impl FileMetadata {
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub(crate) fn new_from_path<P: openat::AsPath>(
         dir: &openat::Dir,
         name: P,
@@ -88,6 +98,7 @@ impl FileMetadata {
 
 impl FileTree {
     // Internal helper to generate a sub-tree
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     fn unsorted_from_dir(dir: &openat::Dir) -> Result<HashMap<String, FileMetadata>> {
         let mut ret = HashMap::new();
         for entry in dir.list_dir(".")? {
@@ -126,6 +137,7 @@ impl FileTree {
     }
 
     /// Create a FileTree from the target directory.
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub(crate) fn new_from_dir(dir: &openat::Dir) -> Result<Self> {
         let mut children = BTreeMap::new();
         for (k, v) in Self::unsorted_from_dir(dir)?.drain() {
@@ -136,6 +148,7 @@ impl FileTree {
     }
 
     /// Determine the changes *from* self to the updated tree
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub(crate) fn diff(&self, updated: &Self) -> Result<FileTreeDiff> {
         self.diff_impl(updated, true)
     }
@@ -155,6 +168,7 @@ impl FileTree {
         current.diff_impl(self, false)
     }
 
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     fn diff_impl(&self, updated: &Self, check_additions: bool) -> Result<FileTreeDiff> {
         let mut additions = HashSet::new();
         let mut removals = HashSet::new();
@@ -186,6 +200,7 @@ impl FileTree {
 
     /// Create a diff from a target directory.  This will ignore
     /// any files or directories that are not part of the original tree.
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub(crate) fn relative_diff_to(&self, dir: &openat::Dir) -> Result<FileTreeDiff> {
         let mut removals = HashSet::new();
         let mut changes = HashSet::new();
@@ -219,6 +234,7 @@ impl FileTree {
 }
 
 // Recursively remove all files in the directory that start with our TMP_PREFIX
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 fn cleanup_tmp(dir: &openat::Dir) -> Result<()> {
     for entry in dir.list_dir(".")? {
         let entry = entry?;
@@ -246,6 +262,7 @@ fn cleanup_tmp(dir: &openat::Dir) -> Result<()> {
 }
 
 #[derive(Default, Clone)]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub(crate) struct ApplyUpdateOptions {
     pub(crate) skip_removals: bool,
     pub(crate) skip_sync: bool,
@@ -255,6 +272,7 @@ pub(crate) struct ApplyUpdateOptions {
 // to be bound in nix today.  I found https://github.com/XuShaohua/nc
 // but that's a nontrivial dependency with not a lot of code review.
 // Let's just fork off a helper process for now.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub(crate) fn syncfs(d: &openat::Dir) -> Result<()> {
     let d = d.sub_dir(".").expect("subdir");
     let mut c = std::process::Command::new("sync");
@@ -272,6 +290,7 @@ pub(crate) fn syncfs(d: &openat::Dir) -> Result<()> {
     Ok(())
 }
 
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 fn tmpname_for_path<P: AsRef<Path>>(path: P) -> std::path::PathBuf {
     let path = path.as_ref();
     let mut buf = path.file_name().expect("filename").to_os_string();
@@ -280,6 +299,7 @@ fn tmpname_for_path<P: AsRef<Path>>(path: P) -> std::path::PathBuf {
 }
 
 /// Given two directories, apply a diff generated from srcdir to destdir
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub(crate) fn apply_diff(
     srcdir: &openat::Dir,
     destdir: &openat::Dir,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@ Refs:
 #![deny(unused_must_use)]
 
 mod backend;
+#[cfg(any(target_arch = "x86_64", target_arch = "powerpc64"))]
+mod bios;
 mod bootupd;
 mod cli;
 mod component;

--- a/src/ostreeutil.rs
+++ b/src/ostreeutil.rs
@@ -7,6 +7,7 @@
 use std::path::Path;
 
 /// https://github.com/coreos/rpm-ostree/pull/969/commits/dc0e8db5bd92e1f478a0763d1a02b48e57022b59
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub(crate) const BOOT_PREFIX: &str = "usr/lib/ostree-boot";
 
 pub(crate) fn rpm_cmd<P: AsRef<Path>>(sysroot: P) -> std::process::Command {

--- a/src/sha512string.rs
+++ b/src/sha512string.rs
@@ -18,6 +18,7 @@ impl fmt::Display for SHA512String {
 }
 
 impl SHA512String {
+    #[allow(dead_code)]
     pub(crate) fn from_hasher(hasher: &mut Hasher) -> Self {
         Self(format!(
             "sha512:{}",

--- a/src/util.rs
+++ b/src/util.rs
@@ -152,6 +152,7 @@ pub(crate) fn rpm_query(sysroot_path: &str, path: &Path) -> Result<Command> {
 /// failure. Returns a Result<String> describing whether the command failed, and if not, its
 /// standard output. Output is assumed to be UTF-8. Errors are adequately prefixed with the full
 /// command.
+#[allow(dead_code)]
 pub(crate) fn cmd_output(cmd: &mut Command) -> Result<String> {
     let result = cmd
         .output()


### PR DESCRIPTION
bootupd: Prepare bootupd update directory for both components
- Prepare bootupd update directory which will save component metadata
files for both components.

---

Add bios.rs and implement generate_update_metadata
- This will generate `/usr/lib/bootupd/updates/BIOS.json`, which will have the version and timestamp of `grub2-tools`

---

bios.rs: implement BIOS (grub) install function
- Add `--device </dev/vda>` option to install BIOS bootloader (grub)
- If call function without `--device`, will only install EFI.

---

bios.rs: add `run_update` to support bootupctl update
- This is the same action as `install`
---

bios.rs: return `Skipped` when run `bootupctl validate` for BIOS

---
ppc64: fix build warning
- The fix looks really ugly. Just realize bootupd is not supported on ppc yet, maybe we will support in future.

---

aarch64: fix build warning

---

Fix https://github.com/coreos/bootupd/issues/53