### PR TITLE
Release 0.2.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "bootupd"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bootupd"
 description = "Bootloader updater"
 license = "Apache-2.0"
-version = "0.2.8"
+version = "0.2.9"
 authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2021"
 rust-version = "1.58.1"


### PR DESCRIPTION
Mainly because bootc work depends on the new EFI handling.