### PR TITLE
bootupd: Prepare bootupd update directory for both components

### DIFF
--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -70,6 +70,10 @@ pub(crate) fn get_components() -> Components {
 }
 
 pub(crate) fn generate_update_metadata(sysroot_path: &str) -> Result<()> {
+    // create bootupd update dir which will save component metadata files for both components
+    let updates_dir = Path::new(sysroot_path).join(crate::model::BOOTUPD_UPDATES_DIR);
+    std::fs::create_dir_all(&updates_dir)
+        .with_context(|| format!("Failed to create updates dir {:?}", &updates_dir))?;
     for component in get_components().values() {
         let v = component.generate_update_metadata(sysroot_path)?;
         println!(

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -257,10 +257,6 @@ impl Component for Efi {
 
             // Fork off mv() because on overlayfs one can't rename() a lower level
             // directory today, and this will handle the copy fallback.
-            let parent = dest_efidir
-                .parent()
-                .ok_or_else(|| anyhow::anyhow!("Expected parent directory"))?;
-            std::fs::create_dir_all(&parent)?;
             Command::new("mv").args(&[&efisrc, &dest_efidir]).run()?;
         }
 


### PR DESCRIPTION
Prepare bootupd update directory which will save component metadata files for both components.