### PR TITLE
xtask: Add timestamp to version

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.68"
 camino = "1.0"
+chrono = { version = "0.4.23", default_features = false, features = ["std"] }
 fn-error-context = "0.2.0"
 tempfile = "3.3"
 xshell = { version = "0.2" }


### PR DESCRIPTION
This is a copy of
https://github.com/containers/bootc/commit/0c8c6834f0aecdf18d8b9eec07a3810743ad0d37

I was hitting an issue with our COPR builds where we were getting *earlier* builds because the git hash was the first component of the version, and the leading numbers there don't increment, and RPM wants higher versions.

Force newer-is-better by injecting the date (up to the minute, not second because we're not going to build more than one a second).