### PR TITLE
bios: Always add `part_gpt`

### DIFF
--- a/src/bios.rs
+++ b/src/bios.rs
@@ -58,10 +58,13 @@ impl Bios {
 
         let mut cmd = Command::new(grub_install);
         let boot_dir = Path::new(dest_root).join("boot");
+        // We forcibly inject mdraid1x because it's needed by CoreOS's default of "install raw disk image"
+        // We also add part_gpt because in some cases probing of the partition map can fail such
+        // as in a container, but we always use GPT.
         #[cfg(target_arch = "x86_64")]
         cmd.args(&["--target", "i386-pc"])
             .args(&["--boot-directory", boot_dir.to_str().unwrap()])
-            .args(&["--modules", "mdraid1x"])
+            .args(&["--modules", "mdraid1x part_gpt"])
             .arg(device);
 
         #[cfg(target_arch = "powerpc64")]


### PR DESCRIPTION
This fixes https://github.com/containers/bootc/issues/64

I didn't chase through what was going wrong in grub; there's a whole lot of layers here.  But for the CoreOS use case we know the modules we need, so we should specify them.