### PR TITLE
build-sys: Use new tier = 2 for cargo-vendor-filterer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,10 @@ authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2021"
 rust-version = "1.66.0"
 
-# See https://github.com/cgwalters/cargo-vendor-filterer
+# See https://github.com/coreos/cargo-vendor-filterer
 [package.metadata.vendor-filter]
-platforms = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
+platforms = ["*-unknown-linux-gnu"]
+tier = "2"
 
 [[bin]]
 name = "bootupd"


### PR DESCRIPTION
While the architecture list here was right today, there's no reason not to just expand our vendoring set.