### PR TITLE
Bump rust-version = 1.70.0 && Release 0.2.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "bootupd"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bootupd"
 description = "Bootloader updater"
 license = "Apache-2.0"
-version = "0.2.9"
+version = "0.2.10"
 authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2021"
 rust-version = "1.70.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 version = "0.2.9"
 authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2021"
-rust-version = "1.66.0"
+rust-version = "1.70.0"
 
 # See https://github.com/coreos/cargo-vendor-filterer
 [package.metadata.vendor-filter]


### PR DESCRIPTION
Bump rust-version = 1.70.0

It's what's in C9S and we can rely on that.

---

Release 0.2.10

---

