### PR TITLE
Fix removal in non-existent files

### DIFF
--- a/src/filetree.rs
+++ b/src/filetree.rs
@@ -337,7 +337,7 @@ pub(crate) fn apply_diff(
     if !opts.skip_removals {
         for path in diff.removals.iter() {
             destdir
-                .remove_file(path)
+                .remove_file_optional(path)
                 .with_context(|| format!("removing {path}"))?;
         }
     }


### PR DESCRIPTION
Tested in Fedora Silverblue 38 upgraded from 34 (upgrades from 36 isn't affected).

Fixes https://github.com/coreos/bootupd/issues/467.