### PR TITLE
install: Add support for selecting components

### DIFF
--- a/src/cli/bootupd.rs
+++ b/src/cli/bootupd.rs
@@ -47,9 +47,14 @@ pub struct InstallOpts {
     /// Target root
     #[clap(value_parser)]
     dest_root: String,
+
     /// Target device, used by bios bootloader installation
-    #[clap(long, value_parser, default_value_t = String::from(""))]
-    device: String,
+    #[clap(long)]
+    device: Option<String>,
+
+    #[clap(long = "component")]
+    /// Only install these components
+    components: Option<Vec<String>>,
 }
 
 #[derive(Debug, Parser)]
@@ -77,8 +82,13 @@ impl DCommand {
 
     /// Runner for `install` verb.
     pub(crate) fn run_install(opts: InstallOpts) -> Result<()> {
-        bootupd::install(&opts.src_root, &opts.dest_root, &opts.device)
-            .context("boot data installation failed")?;
+        bootupd::install(
+            &opts.src_root,
+            &opts.dest_root,
+            opts.device.as_deref(),
+            opts.components.as_deref(),
+        )
+        .context("boot data installation failed")?;
         Ok(())
     }
 }


### PR DESCRIPTION
So one can use e.g. `--component=EFI` to only install UEFI.