### PR TITLE
 Add support for installing static grub configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,4 +46,5 @@ install: install-units
 	ln -s ../bootupd.socket "${DESTDIR}$(PREFIX)/lib/systemd/system/multi-user.target.wants"
 
 install-grub-static:
-	install -D -t ${DESTDIR}$(PREFIX)/lib/bootupd/grub2-static src/grub2/*.cfg
+	install -m 644 -D -t ${DESTDIR}$(PREFIX)/lib/bootupd/grub2-static src/grub2/*.cfg
+	install -m 755 -d ${DESTDIR}$(PREFIX)/lib/bootupd/grub2-static/configs.d

--- a/src/cli/bootupd.rs
+++ b/src/cli/bootupd.rs
@@ -52,6 +52,10 @@ pub struct InstallOpts {
     #[clap(long)]
     device: Option<String>,
 
+    /// Enable installation of the built-in static config files
+    #[clap(long)]
+    with_static_configs: bool,
+
     #[clap(long = "component")]
     /// Only install these components
     components: Option<Vec<String>>,
@@ -90,6 +94,7 @@ impl DCommand {
             &opts.src_root,
             &opts.dest_root,
             opts.device.as_deref(),
+            opts.with_static_configs,
             opts.components.as_deref(),
         )
         .context("boot data installation failed")?;

--- a/src/grub2/configs.d/README.md
+++ b/src/grub2/configs.d/README.md
@@ -1,0 +1,4 @@
+Add drop-in grub fragments into this directory to have
+them be installed into the final config.
+
+The filenames must end in `.cfg`.

--- a/src/grub2/grub-static-post.cfg
+++ b/src/grub2/grub-static-post.cfg
@@ -1,0 +1,17 @@
+if [ x$feature_timeout_style = xy ] ; then
+  set timeout_style=menu
+  set timeout=1
+# Fallback normal timeout code in case the timeout_style feature is
+# unavailable.
+else
+  set timeout=1
+fi
+
+# Import user defined configuration
+# tracker: https://github.com/coreos/fedora-coreos-tracker/issues/805
+if [ -f $prefix/user.cfg ]; then
+  source $prefix/user.cfg
+fi
+
+blscfg
+

--- a/src/grub2/grub-static-pre.cfg
+++ b/src/grub2/grub-static-pre.cfg
@@ -59,25 +59,4 @@ function load_video {
   fi
 }
 
-# tracker: https://github.com/coreos/fedora-coreos-tracker/issues/805
-if [ -f $prefix/platform.cfg ]; then
-  source $prefix/platform.cfg
-fi
-
-if [ x$feature_timeout_style = xy ] ; then
-  set timeout_style=menu
-  set timeout=1
-# Fallback normal timeout code in case the timeout_style feature is
-# unavailable.
-else
-  set timeout=1
-fi
-
-# Import user defined configuration
-# tracker: https://github.com/coreos/fedora-coreos-tracker/issues/805
-if [ -f $prefix/user.cfg ]; then
-  source $prefix/user.cfg
-fi
-
-blscfg
-
+# Other package code will be injected from here

--- a/src/grubconfigs.rs
+++ b/src/grubconfigs.rs
@@ -1,0 +1,111 @@
+use std::fmt::Write;
+use std::os::unix::prelude::OsStrExt;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+use fn_error_context::context;
+use openat_ext::OpenatDirExt;
+
+/// The subdirectory of /boot we use
+const GRUB2DIR: &str = "grub2";
+const CONFIGDIR: &str = "/usr/lib/bootupd/grub2-static";
+const DROPINDIR: &str = "configs.d";
+
+#[context("Locating EFI vendordir")]
+pub(crate) fn find_efi_vendordir(efidir: &openat::Dir) -> Result<PathBuf> {
+    for d in efidir.list_dir(".")? {
+        let d = d?;
+        if d.file_name().as_bytes() == b"BOOT" {
+            continue;
+        }
+        let meta = efidir.metadata(d.file_name())?;
+        if !meta.is_dir() {
+            continue;
+        }
+        return Ok(d.file_name().into());
+    }
+    anyhow::bail!("Failed to find EFI vendor dir")
+}
+
+/// Install the static GRUB config files.
+#[context("Installing static GRUB configs")]
+pub(crate) fn install(target_root: &openat::Dir, efi: bool) -> Result<()> {
+    let bootdir = &target_root.sub_dir("boot").context("Opening /boot")?;
+
+    let mut config = std::fs::read_to_string(Path::new(CONFIGDIR).join("grub-static-pre.cfg"))?;
+
+    let dropindir = openat::Dir::open(&Path::new(CONFIGDIR).join(DROPINDIR))?;
+    // Sort the files for reproducibility
+    let mut entries = dropindir
+        .list_dir(".")?
+        .map(|e| e.map_err(anyhow::Error::msg))
+        .collect::<Result<Vec<_>>>()?;
+    entries.sort_by(|a, b| a.file_name().cmp(b.file_name()));
+    for ent in entries {
+        let name = ent.file_name();
+        let name = name
+            .to_str()
+            .ok_or_else(|| anyhow!("Invalid UTF-8: {name:?}"))?;
+        if !name.ends_with(".cfg") {
+            log::debug!("Ignoring {name}");
+            continue;
+        }
+        writeln!(config, "source $prefix/{name}")?;
+        dropindir
+            .copy_file_at(name, bootdir, format!("{GRUB2DIR}/{name}"))
+            .with_context(|| format!("Copying {name}"))?;
+        println!("Installed {name}");
+    }
+
+    {
+        let post = std::fs::read_to_string(Path::new(CONFIGDIR).join("grub-static-post.cfg"))?;
+        config.push_str(post.as_str());
+    }
+
+    bootdir
+        .write_file_contents(format!("{GRUB2DIR}/grub.cfg"), 0o644, config.as_bytes())
+        .context("Copying grub-static.cfg")?;
+    println!("Installed: grub.cfg");
+
+    let efidir = efi
+        .then(|| {
+            target_root
+                .sub_dir_optional("boot/efi/EFI")
+                .context("Opening /boot/efi/EFI")
+        })
+        .transpose()?
+        .flatten();
+    if let Some(efidir) = efidir.as_ref() {
+        let vendordir = find_efi_vendordir(efidir)?;
+        log::debug!("vendordir={:?}", &vendordir);
+        let target = &vendordir.join("grub.cfg");
+        efidir
+            .copy_file(&Path::new(CONFIGDIR).join("grub-static-efi.cfg"), target)
+            .context("Copying static EFI")?;
+        println!("Installed: {target:?}");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore]
+    fn test_install() -> Result<()> {
+        env_logger::init();
+        let td = tempfile::tempdir()?;
+        let tdp = td.path();
+        let td = openat::Dir::open(tdp)?;
+        std::fs::create_dir_all(tdp.join("boot/grub2"))?;
+        std::fs::create_dir_all(tdp.join("boot/efi/EFI/BOOT"))?;
+        std::fs::create_dir_all(tdp.join("boot/efi/EFI/fedora"))?;
+        install(&td, true).unwrap();
+
+        assert!(td.exists("boot/grub2/grub.cfg")?);
+        assert!(td.exists("boot/efi/EFI/fedora/grub.cfg")?);
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,12 @@ mod daemon;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 mod efi;
 mod filetree;
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "powerpc64"
+))]
+mod grubconfigs;
 mod ipc;
 mod model;
 mod model_legacy;


### PR DESCRIPTION
grub: Support multiple platform files

In practice, just one should be enough but let's expand
in case.

---

Add support for installing static grub configs

Currently these are duplicated in osbuild and coreos-assembler.
We will aim to deduplicate them here.

Ideally we'd add support for "day 2" updates of these; I started
on a patch for that but it's sadly messy.

This is an incremental improvement.

---

