### PR TITLE
grub.cfg: drop `set pager=1`

### DIFF
--- a/src/grub2/grub-static-pre.cfg
+++ b/src/grub2/grub-static-pre.cfg
@@ -1,7 +1,6 @@
 # This file is copied from https://github.com/coreos/coreos-assembler/blob/main/src/grub.cfg
 # Changes:
 #   - Dropped Ignition glue, that can be injected into platform.cfg
-set pager=1
 # petitboot doesn't support -e and doesn't support an empty path part
 if [ -d (md/md-boot)/grub2 ]; then
   # fcct currently creates /boot RAID with superblock 1.0, which allows


### PR DESCRIPTION
This was in the very first commit that added a GRUB config to cosa. If set, it causes GRUB to pause output if the screen is full of messages until the user presses a key.

That's just incompatible with automation, so nuke it. Any warnings from GRUB should end up in the serial console logs still.

One way this can happen is if booting from multipath. GRUB tries each path in turn until it can read from it. For each tried path that's non- optimized, it'll log a message. So if the device has a large enough number of paths, we can trigger the pager functionality and hang boot.

Probably fixes: https://issues.redhat.com/browse/OCPBUGS-20123