### PR TITLE
grubconfigs: Ensure grub2 dir exists

### DIFF
--- a/src/grubconfigs.rs
+++ b/src/grubconfigs.rs
@@ -62,6 +62,10 @@ pub(crate) fn install(target_root: &openat::Dir, efi: bool) -> Result<()> {
         config.push_str(post.as_str());
     }
 
+    if !bootdir.exists(GRUB2DIR)? {
+        bootdir.create_dir(GRUB2DIR, 0o700)?;
+    }
+
     bootdir
         .write_file_contents(format!("{GRUB2DIR}/grub.cfg"), 0o644, config.as_bytes())
         .context("Copying grub-static.cfg")?;


### PR DESCRIPTION
I hit this when testing `bootc install` in a loop, it seems like we could be implicitly depending on this directory already having been created.