### PR TITLE
Add support for root=boot (with EFI) and writing UUID file

### DIFF
--- a/src/bios.rs
+++ b/src/bios.rs
@@ -93,6 +93,7 @@ impl Component for Bios {
         src_root: &openat::Dir,
         dest_root: &str,
         device: &str,
+        _update_firmware: bool,
     ) -> Result<InstalledContent> {
         let meta = if let Some(meta) = get_component_update(src_root, self)? {
             meta

--- a/src/component.rs
+++ b/src/component.rs
@@ -50,6 +50,7 @@ pub(crate) trait Component {
         src_root: &openat::Dir,
         dest_root: &str,
         device: &str,
+        update_firmware: bool,
     ) -> Result<InstalledContent>;
 
     /// Implementation of `bootupd generate-update-metadata` for a given component.

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,0 +1,44 @@
+use std::os::fd::AsRawFd;
+use std::os::unix::process::CommandExt;
+use std::process::Command;
+
+use anyhow::{Context, Result};
+use fn_error_context::context;
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "kebab-case")]
+#[allow(dead_code)]
+pub(crate) struct Filesystem {
+    pub(crate) source: String,
+    pub(crate) fstype: String,
+    pub(crate) options: String,
+    pub(crate) uuid: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct Findmnt {
+    pub(crate) filesystems: Vec<Filesystem>,
+}
+
+#[context("Inspecting filesystem {path:?}")]
+pub(crate) fn inspect_filesystem(root: &openat::Dir, path: &str) -> Result<Filesystem> {
+    let rootfd = root.as_raw_fd();
+    // SAFETY: This is unsafe just for the pre_exec, when we port to cap-std we can use cap-std-ext
+    let o = unsafe {
+        Command::new("findmnt")
+            .args(["-J", "-v", "--output-all", path])
+            .pre_exec(move || nix::unistd::fchdir(rootfd).map_err(Into::into))
+            .output()?
+    };
+    let st = o.status;
+    if !st.success() {
+        anyhow::bail!("findmnt failed: {st:?}");
+    }
+    let o: Findmnt = serde_json::from_reader(std::io::Cursor::new(&o.stdout))
+        .context("Parsing findmnt output")?;
+    o.filesystems
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("findmnt returned no data"))
+}

--- a/src/grub2/grub-static-efi.cfg
+++ b/src/grub2/grub-static-efi.cfg
@@ -13,7 +13,12 @@ else
     search --label boot --set prefix --no-floppy
   fi
 fi
-set prefix=($prefix)/grub2
-configfile $prefix/grub.cfg
+if [ -d ($prefix)/grub2 ]; then
+  set prefix=($prefix)/grub2
+  configfile $prefix/grub.cfg
+else
+  set prefix=($prefix)/boot/grub2
+  configfile $prefix/grub.cfg
+fi
 boot
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod coreos;
 mod daemon;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 mod efi;
+mod filesystem;
 mod filetree;
 #[cfg(any(
     target_arch = "x86_64",


### PR DESCRIPTION

In FCOS we never tried to support root=boot, but for bootupd
to do alongside installs in the general case we have to.

There were two things to fix here:

 - Tweak the EFI "trampoline" to check for both $prefix/grub.cfg and $prefix/boot/grub.cfg
 - Add support for writing the boot UUID into both places

(This avoids higher level tools like bootupd needing to know
 about how to find the EFI vendor dir)

This more fully replicates the logic in coreos-installer.

---

