### PR TITLE
two minor patches + c9s compat

### DIFF
--- a/src/efi.rs
+++ b/src/efi.rs
@@ -454,15 +454,17 @@ pub(crate) fn clear_efi_current() -> Result<()> {
         log::debug!("No EFI {BOOTCURRENT} found");
         return Ok(());
     };
+    log::debug!("EFI current: {current}");
     let output = Command::new(EFIBOOTMGR)
         .args(["-b", current, "-B"])
         .output()?;
-    if !output.status.success() {
+    let st = output.status;
+    if !st.success() {
         std::io::copy(
             &mut std::io::Cursor::new(output.stderr),
             &mut std::io::stderr().lock(),
         )?;
-        anyhow::bail!("Failed to invoke {EFIBOOTMGR}");
+        anyhow::bail!("Failed to invoke {EFIBOOTMGR}: {st:?}");
     }
     anyhow::Ok(())
 }

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -28,7 +28,7 @@ pub(crate) fn inspect_filesystem(root: &openat::Dir, path: &str) -> Result<Files
     // SAFETY: This is unsafe just for the pre_exec, when we port to cap-std we can use cap-std-ext
     let o = unsafe {
         Command::new("findmnt")
-            .args(["-J", "-v", "--output-all", path])
+            .args(["-J", "-v", "--output=SOURCE,FSTYPE,OPTIONS,UUID", path])
             .pre_exec(move || nix::unistd::fchdir(rootfd).map_err(Into::into))
             .output()?
     };

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,3 +1,4 @@
+use std::io::Write;
 use std::os::fd::AsRawFd;
 use std::os::unix::process::CommandExt;
 use std::process::Command;
@@ -33,6 +34,7 @@ pub(crate) fn inspect_filesystem(root: &openat::Dir, path: &str) -> Result<Files
     };
     let st = o.status;
     if !st.success() {
+        let _ = std::io::stderr().write_all(&o.stderr)?;
         anyhow::bail!("findmnt failed: {st:?}");
     }
     let o: Findmnt = serde_json::from_reader(std::io::Cursor::new(&o.stdout))


### PR DESCRIPTION
efi: Add more debugging for efibootmgr invocation

- Show what `bootcurrent` is
- Add the process exit status

---

filesystem: Copy stderr on failure

To aid debugging.

---

filesystem: Only capture needed columns

This fixes compatibility with current c9s `findmnt`, which otherwise
errors out with
`findmnt: ACTION column is requested, but --poll is not enabled`

---

