### PR TITLE
grubconfigs: move the GRUB2DIR creation earlier

### DIFF
--- a/src/grubconfigs.rs
+++ b/src/grubconfigs.rs
@@ -38,6 +38,10 @@ pub(crate) fn install(target_root: &openat::Dir, efi: bool, write_uuid: bool) ->
         root_dev != boot_dev
     };
 
+    if !bootdir.exists(GRUB2DIR)? {
+        bootdir.create_dir(GRUB2DIR, 0o700)?;
+    }
+
     let mut config = std::fs::read_to_string(Path::new(CONFIGDIR).join("grub-static-pre.cfg"))?;
 
     let dropindir = openat::Dir::open(&Path::new(CONFIGDIR).join(DROPINDIR))?;
@@ -66,10 +70,6 @@ pub(crate) fn install(target_root: &openat::Dir, efi: bool, write_uuid: bool) ->
     {
         let post = std::fs::read_to_string(Path::new(CONFIGDIR).join("grub-static-post.cfg"))?;
         config.push_str(post.as_str());
-    }
-
-    if !bootdir.exists(GRUB2DIR)? {
-        bootdir.create_dir(GRUB2DIR, 0o700)?;
     }
 
     bootdir


### PR DESCRIPTION
We add the GRUB2DIR creation in ece9120 but there is an earlier use of that directory if there are dropins so let's move the creation of the directory earlier before the dropins are processed.

I hit this because I'm testing out things on FCOS. Building a qemu and metal image works just fine, because in that case we are doing the MBR install using `grub2-install` and I guess that tool creates the directory. In the metal4k case, though, there is no BIOS install and thus we get here and the GRUB2DIR doesn't exist and bootupd fails.