### PR TITLE
ci: Add a workflow which does an install via bootc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+permissions:
+  actions: read
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  c9s-bootc-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      # We use docker to build because it updates to the latest, whereas right now ubuntu-latest
+      # has podman and buildah from ~2021 (insane!)
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v3
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: "build-c9s"
+      - name: Build and export to Docker
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ci/Containerfile.c9s
+          load: true
+          tags: localhost/bootupd:latest
+      - name: Copy to podman
+        run: sudo skopeo copy docker-daemon:localhost/bootupd:latest containers-storage:localhost/bootupd:latest
+      - name: bootc install
+        run: |
+          set -xeuo pipefail
+          sudo podman run --rm -ti --privileged -v /:/target --pid=host --security-opt label=disable \
+            -v /var/lib/containers:/var/lib/containers \
+            localhost/bootupd:latest bootc install to-filesystem --skip-fetch-check \
+            --disable-selinux --replace=alongside /target

--- a/Makefile
+++ b/Makefile
@@ -48,3 +48,8 @@ install: install-units
 install-grub-static:
 	install -m 644 -D -t ${DESTDIR}$(PREFIX)/lib/bootupd/grub2-static src/grub2/*.cfg
 	install -m 755 -d ${DESTDIR}$(PREFIX)/lib/bootupd/grub2-static/configs.d
+
+bin-archive:
+	rm target/inst -rf
+	$(MAKE) install install-grub-static DESTDIR=$$(pwd)/target/inst
+	tar -C target/inst -c --zstd -f target/bootupd.tar.zst .

--- a/ci/Containerfile.c9s
+++ b/ci/Containerfile.c9s
@@ -1,0 +1,13 @@
+# This container build is just a demo effectively; it shows how one might
+# build bootc in a container flow, using Fedora ELN as the target.
+FROM quay.io/centos/centos:stream9 as build
+RUN dnf -y install dnf-utils zstd && dnf builddep -y rust-bootupd
+COPY . /build
+WORKDIR /build
+# See https://www.reddit.com/r/rust/comments/126xeyx/exploring_the_problem_of_faster_cargo_docker/
+# We aren't using the full recommendations there, just the simple bits.
+RUN --mount=type=cache,target=/build/target --mount=type=cache,target=/var/roothome make && make bin-archive && mkdir -p /out && cp target/bootupd.tar.zst /out
+
+FROM quay.io/centos-bootc/centos-bootc-dev:stream9
+COPY --from=build /out/bootupd.tar.zst /tmp
+RUN tar -C / --zstd -xvf /tmp/bootupd.tar.zst && rm -vf /tmp/*


### PR DESCRIPTION
This helps effectively test e2e things like `--with-static-configs`.