### PR TITLE
model: Add tracking of our own static config versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,5 @@ jobs:
             -v /var/lib/containers:/var/lib/containers \
             localhost/bootupd:latest bootc install to-filesystem --skip-fetch-check \
             --disable-selinux --replace=alongside /target
+          # Verify we injected static configs
+          jq -re '.["static-configs"].version' /boot/bootupd-state.json

--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -108,6 +108,8 @@ pub(crate) fn install(
 
     match configs.enabled_with_uuid() {
         Some(uuid) => {
+            let self_meta = crate::packagesystem::query_files("/", ["/usr/bin/bootupctl"])?;
+            state.static_configs = Some(self_meta);
             #[cfg(any(
                 target_arch = "x86_64",
                 target_arch = "aarch64",

--- a/src/model.rs
+++ b/src/model.rs
@@ -50,6 +50,8 @@ pub(crate) struct SavedState {
     pub(crate) installed: BTreeMap<String, InstalledContent>,
     /// Maps a component name to an in progress update
     pub(crate) pending: Option<BTreeMap<String, ContentMetadata>>,
+    /// If static bootloader configs are enabled, this contains the version
+    pub(crate) static_configs: Option<ContentMetadata>,
 }
 
 /// The status of an individual component.


### PR DESCRIPTION
Currently our static configs don't directly support updates. (They really should)

We also have a use case around simply introspecting the state that static configs were enabled (xref https://github.com/ostreedev/ostree/pull/3150) where we want to have ostree not run grub2-mkconfig in this case.

In preparation for both of these things, add tracking of our *own* version of the static configs into the metadata.

In theory of course, static configs could include other components (ignition, greenboot, etc.) and we should track those too.  For now this at least gets us basic metadata.