### PR TITLE
grub2: source in a console.cfg file if exists

### DIFF
--- a/src/grub2/grub-static-pre.cfg
+++ b/src/grub2/grub-static-pre.cfg
@@ -38,6 +38,11 @@ elif [ -s $prefix/grubenv ]; then
   load_env
 fi
 
+if [ -f $prefix/console.cfg ]; then
+  # Source in any GRUB console settings if provided by the user/platform
+  source $prefix/console.cfg
+fi
+
 if [ x"${feature_menuentry_id}" = xy ]; then
   menuentry_id_option="--id"
 else


### PR DESCRIPTION
This will allow users or distro builders place console settings here that will get picked up on boot. This was discussed as part of https://github.com/coreos/fedora-coreos-tracker/issues/1671