### PR TITLE
deps-update: bump chrono from 0.4.34 to 0.4.35

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.34"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3.2"
-chrono = { version = "0.4.34", features = ["serde"] }
+chrono = { version = "0.4.35", features = ["serde"] }
 clap = { version = "3.2", default-features = false, features = ["cargo", "derive", "std", "suggestions"] }
 env_logger = "0.10"
 fn-error-context = "0.2.1"

--- a/src/model.rs
+++ b/src/model.rs
@@ -135,7 +135,7 @@ mod test {
             version: "v1".into(),
         };
         let b = ContentMetadata {
-            timestamp: t + Duration::seconds(1),
+            timestamp: t + Duration::try_seconds(1).unwrap(),
             version: "v2".into(),
         };
         assert!(a.can_upgrade_to(&b));


### PR DESCRIPTION
Xerf to https://github.com/chronotope/chrono/pull/1450