### PR TITLE
Print previous version too when updating

### DIFF
--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -431,7 +431,7 @@ pub(crate) fn client_run_update(c: &mut ipc::ClientToDaemonConnection) -> Result
                 continue;
             }
             ComponentUpdateResult::Updated {
-                previous: _,
+                previous,
                 interrupted,
                 new,
             } => {
@@ -441,6 +441,7 @@ pub(crate) fn client_run_update(c: &mut ipc::ClientToDaemonConnection) -> Result
                         i.version,
                     );
                 }
+                println!("Previous {}: {}", name, previous.version);
                 println!("Updated {}: {}", name, new.version);
             }
         }

--- a/tests/e2e-update/e2e-update-in-vm.sh
+++ b/tests/e2e-update/e2e-update-in-vm.sh
@@ -68,6 +68,7 @@ tmpefimount=$(mount_tmp_efi)
 assert_not_has_file ${tmpefimount}/EFI/fedora/test-bootupd.efi
 
 bootupctl update | tee out.txt
+assert_file_has_content out.txt "Previous EFI: .*"
 assert_file_has_content out.txt "Updated EFI: ${TARGET_GRUB_PKG}.*,test-bootupd-payload-1.0"
 
 assert_file_has_content ${tmpefimount}/EFI/fedora/test-bootupd.efi test-payload


### PR DESCRIPTION
Keep current format to avoid having to update Fedora CoreOS tests as well.

Based on: https://github.com/coreos/bootupd/pull/472
Co-authored-by: Colin Walters <walters@verbum.org>
Closes: https://github.com/coreos/bootupd/issues/445