### PR TITLE
grubconfig: find correct efi vendordir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "walkdir",
  "widestring",
 ]
 
@@ -700,6 +701,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,6 +864,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 tempfile = "^3.10"
 widestring = "1.1.0"
+walkdir = "2.3.2"
 
 [profile.release]
 # We assume we're being delivered via e.g. RPM which supports split debuginfo

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -137,7 +137,7 @@ impl Efi {
             return Ok(());
         }
         let efidir = &espdir.sub_dir("EFI").context("Opening EFI")?;
-        let vendordir = super::grubconfigs::find_efi_vendordir(efidir)?;
+        let vendordir = super::grubconfigs::find_efi_vendordir(efidir, None)?;
         let vendordir = vendordir
             .to_str()
             .ok_or_else(|| anyhow::anyhow!("Invalid non-UTF-8 vendordir"))?;


### PR DESCRIPTION
Refer to Timothée's comment:
There are cases where could have multiple shim binaries in the EFI partition and we only want to touch our own, not others.

The logic should be:
- Look at what we have in: `/usr/lib/bootupd/updates/EFI/foo/bar`
- Find the corresponding file in the EFI partition: `/boot/efi/ EFI/foo/bar`
- Update the file if needed

See https://github.com/coreos/bootupd/issues/630#issuecomment-2063529216