### PR TITLE
Add `get_efi_vendor` method to both the bios and efi backends

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,23 @@ jobs:
           tags: localhost/bootupd:latest
       - name: Copy to podman
         run: sudo skopeo copy docker-daemon:localhost/bootupd:latest containers-storage:localhost/bootupd:latest
-      - name: bootc install
+      - name: bootc install to disk
+        run: |
+          set -xeuo pipefail
+          sudo truncate -s 10G myimage.raw
+          sudo podman run --rm -ti --privileged -v .:/target --pid=host --security-opt label=disable \
+            -v /var/lib/containers:/var/lib/containers \
+            -v /dev:/dev \
+            localhost/bootupd:latest bootc install to-disk --skip-fetch-check \
+            --disable-selinux --generic-image --via-loopback /target/myimage.raw
+          # Verify we installed grub.cfg and shim on the disk
+          sudo losetup -P -f myimage.raw
+          device=$(losetup --list --noheadings --output NAME,BACK-FILE | grep myimage.raw | awk '{print $1}')
+          sudo mount "${device}p2" /mnt/
+          sudo ls /mnt/EFI/centos/{grub.cfg,shimx64.efi}
+          sudo losetup -D "${device}"
+          sudo rm -f myimage.raw
+      - name: bootc install to filesystem
         run: |
           set -xeuo pipefail
           sudo podman run --rm -ti --privileged -v /:/target --pid=host --security-opt label=disable \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "walkdir",
  "widestring",
 ]
 
@@ -700,6 +701,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,6 +864,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 tempfile = "^3.10"
 widestring = "1.1.0"
+walkdir = "2.3.2"
 
 [profile.release]
 # We assume we're being delivered via e.g. RPM which supports split debuginfo

--- a/src/bios.rs
+++ b/src/bios.rs
@@ -155,4 +155,8 @@ impl Component for Bios {
     fn validate(&self, _: &InstalledContent) -> Result<ValidationResult> {
         Ok(ValidationResult::Skip)
     }
+
+    fn get_efi_vendor(&self, _: &openat::Dir) -> Result<Option<String>> {
+        Ok(None)
+    }
 }


### PR DESCRIPTION
Add `get_efi_vendor` method to both the bios and efi backends.
See Colin's comment
https://github.com/coreos/bootupd/pull/646#issuecomment-2089226909

---
ci: add `bootc install to-disk` test in c9s-bootc-e2e