### PR TITLE
efi: change `--update-firmware` to match current Anaconda logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,7 @@ dependencies = [
  "openat",
  "openat-ext",
  "openssl",
+ "os-release",
  "serde",
  "serde_json",
  "tempfile",
@@ -388,6 +389,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +570,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "os-release"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f29ae2f71b53ec19cc23385f8e4f3d90975195aa3d09171ba3bef7159bec27"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -666,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ nix = ">= 0.22.1, < 0.24.0"
 openat = "0.1.20"
 openat-ext = ">= 0.2.2, < 0.3.0"
 openssl = "^0.10"
+os-release = "0.1.0"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 tempfile = "^3.10"


### PR DESCRIPTION
Copy Timothée's comment:
We want to be able to use `bootupd backend install --update-firmware`
 in Anaconda to setup the boot order on EFI systems.

The issue is that when called with `--update-firmware`, bootupd
currently removes the `BootCurrent` boot entry, and then adds a
new BootEntry for the system being installed.

The current Anaconda behavior is to remove all boot entries that
match the product name, then create a new boot entry using the
product name and set it as the first one in the boot order.

To sync with Anaconda behavior, when called with `--update-firmware`,
bootupd will remove all boot entries that match the product name, 
using the same Anaconda definition 
`ANACONDA_PRODUCTNAME=$(sed -r -e 's/ *release.*//' /etc/system-release)`
from https://github.com/rhinstaller/anaconda/blob/f52880c8ac0f0b19d5e4b7887c80aedec1d4bfa7/data/liveinst/liveinst#L46, and also creates a new boot entry.

See https://github.com/coreos/bootupd/issues/658