### PR TITLE
bootupd.spec: remove `%{_unitdir}`

### DIFF
--- a/contrib/packaging/bootupd.spec
+++ b/contrib/packaging/bootupd.spec
@@ -29,8 +29,7 @@ BuildRequires: systemd-devel
 %license LICENSE
 %doc README.md
 %{_bindir}/bootupctl
-%{_libexecdir}/bootupd  
-%{_unitdir}/*
+%{_libexecdir}/bootupd
 %{_prefix}/lib/bootupd/grub2-static/
 
 %prep


### PR DESCRIPTION
Drop systemd service since https://github.com/coreos/bootupd/commit/261fb5e7f28b9bd2c6099fd2d484f158adffb221, so we do not need this. See error in ci log:
```
RPM build errors:
    File not found: /builddir/build/BUILD/bootupd-xxx-build/BUILDROOT/usr/lib/systemd/system/*
```