### PR TITLE
efi: update the ESP by creating a tmpdir and RENAME_EXCHANGE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,7 @@ version = "0.2.20"
 dependencies = [
  "anyhow",
  "bincode",
+ "camino",
  "cap-std-ext",
  "chrono",
  "clap",
@@ -157,6 +158,12 @@ name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "camino"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
 
 [[package]]
 name = "cap-primitives"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,7 @@ dependencies = [
  "chrono",
  "clap",
  "env_logger",
+ "fail",
  "fn-error-context",
  "fs2",
  "hex",
@@ -359,6 +360,17 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "fail"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5e43d0f78a42ad591453aedb1d7ae631ce7ee445c7643691055a9ed8d3b01c"
+dependencies = [
+ "log",
+ "once_cell",
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/main.rs"
 anyhow = "1.0"
 bincode = "1.3.2"
 cap-std-ext = "4.0.0"
+camino = "1.1.7"
 chrono = { version = "0.4.38", features = ["serde"] }
 clap = { version = "4.5", default-features = false, features = ["cargo", "derive", "std", "help", "usage", "suggestions"] }
 env_logger = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ camino = "1.1.7"
 chrono = { version = "0.4.38", features = ["serde"] }
 clap = { version = "4.5", default-features = false, features = ["cargo", "derive", "std", "help", "usage", "suggestions"] }
 env_logger = "0.11"
+fail = { version = "0.5", features = ["failpoints"] }
 fn-error-context = "0.2.1"
 fs2 = "0.4.3"
 hex = "0.4.3"

--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -396,6 +396,7 @@ pub(crate) fn print_status(status: &Status) -> Result<()> {
 }
 
 pub(crate) fn client_run_update() -> Result<()> {
+    crate::try_fail_point!("update");
     let status: Status = status()?;
     if status.components.is_empty() && status.adoptable.is_empty() {
         println!("No components installed.");
@@ -488,4 +489,18 @@ pub(crate) fn client_run_validate() -> Result<()> {
         anyhow::bail!("Caught validation errors");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_failpoint_update() {
+        let guard = fail::FailScenario::setup();
+        fail::cfg("update", "return").unwrap();
+        let r = client_run_update();
+        assert_eq!(r.is_err(), true);
+        guard.teardown();
+    }
 }

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -141,7 +141,7 @@ impl Efi {
             log::debug!("Not booted via EFI, skipping firmware update");
             return Ok(());
         }
-        let sysroot = Dir::open_ambient_dir(&Path::new("/"), cap_std::ambient_authority())?;
+        let sysroot = Dir::open_ambient_dir("/", cap_std::ambient_authority())?;
         let product_name = get_product_name(&sysroot)?;
         log::debug!("Get product name: {product_name}");
         assert!(product_name.len() > 0);

--- a/src/failpoints.rs
+++ b/src/failpoints.rs
@@ -1,0 +1,21 @@
+//! Wrappers and utilities on top of the `fail` crate.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// TODO: Use https://github.com/tikv/fail-rs/pull/68 once it merges
+/// copy from https://github.com/coreos/rpm-ostree/commit/aa8d7fb0ceaabfaf10252180e2ddee049d07aae3#diff-adcc419e139605fae34d17b31418dbaf515af2fe9fb766fcbdb2eaad862b3daa
+#[macro_export]
+macro_rules! try_fail_point {
+    ($name:expr) => {{
+        if let Some(e) = fail::eval($name, |msg| {
+            let msg = msg.unwrap_or_else(|| "synthetic failpoint".to_string());
+            anyhow::Error::msg(msg)
+        }) {
+            return Err(From::from(e));
+        }
+    }};
+    ($name:expr, $cond:expr) => {{
+        if $cond {
+            $crate::try_fail_point!($name);
+        }
+    }};
+}

--- a/src/filetree.rs
+++ b/src/filetree.rs
@@ -395,6 +395,7 @@ pub(crate) fn apply_diff(
                 .local_rename(tmp, dst)
                 .with_context(|| format!("rename for {} and {:?}", tmp, dst))?;
         }
+        crate::try_fail_point!("update::exchange");
     }
     // Ensure all of the updates & changes are written persistently to disk
     if !opts.skip_sync {
@@ -705,7 +706,6 @@ mod tests {
             let b_btime_foo_new = fs::metadata(pb.join(foo))?.created()?;
             assert_eq!(b_btime_foo_new, b_btime_foo);
         }
-
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod component;
 mod coreos;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 mod efi;
+mod failpoints;
 mod filesystem;
 mod filetree;
 #[cfg(any(
@@ -43,6 +44,7 @@ use clap::crate_name;
 
 /// Binary entrypoint, for both daemon and client logic.
 fn main() {
+    let _scenario = fail::FailScenario::setup();
     let exit_code = run_cli();
     std::process::exit(exit_code);
 }

--- a/tests/e2e-update/e2e-update-in-vm.sh
+++ b/tests/e2e-update/e2e-update-in-vm.sh
@@ -67,7 +67,12 @@ tmpefimount=$(mount_tmp_efi)
 
 assert_not_has_file ${tmpefimount}/EFI/fedora/test-bootupd.efi
 
-bootupctl update | tee out.txt
+if env FAILPOINTS='update::exchange=return' bootupctl update -vvv 2>err.txt; then
+    fatal "should have errored"
+fi
+assert_file_has_content err.txt "error: .*synthetic failpoint"
+
+bootupctl update -vvv | tee out.txt
 assert_file_has_content out.txt "Previous EFI: .*"
 assert_file_has_content out.txt "Updated EFI: ${TARGET_GRUB_PKG}.*,test-bootupd-payload-1.0"
 

--- a/tests/e2e-update/e2e-update.sh
+++ b/tests/e2e-update/e2e-update.sh
@@ -24,10 +24,14 @@ export test_tmpdir=${testtmp}
 
 # This is new content for our update
 test_bootupd_payload_file=/boot/efi/EFI/fedora/test-bootupd.efi
+test_bootupd_payload_file1=/boot/efi/EFI/BOOT/test-bootupd1.efi
 build_rpm test-bootupd-payload \
-  files ${test_bootupd_payload_file} \
+  files "${test_bootupd_payload_file}
+         ${test_bootupd_payload_file1}" \
   install "mkdir -p %{buildroot}/$(dirname ${test_bootupd_payload_file})
-           echo test-payload > %{buildroot}/${test_bootupd_payload_file}"
+           echo test-payload > %{buildroot}/${test_bootupd_payload_file}
+           mkdir -p %{buildroot}/$(dirname ${test_bootupd_payload_file1})
+           echo test-payload1 > %{buildroot}/${test_bootupd_payload_file1}"
 
 # Start in cosa dir
 cd ${COSA_DIR}


### PR DESCRIPTION
See Timothée's comment https://github.com/coreos/bootupd/issues/454#issuecomment-2178227050
Reuse `TMP_PREFIX`, logic is like this:
- `cp -a fedora .btmp.fedora`
  - We start with a copy to make sure to keep all other files
that we do not explicitly track in bootupd
- Update the content of `.btmp.fedora` with the new binaries
- Exchange `.btmp.fedora` -> `fedora`
- Remove now "old" `.btmp.fedora`

If we have a file not in a directory in `EFI`, then we can copy
it to `.btmp.foo` and then act on it and finally rename it. No
need to copy the entire `EFI`.

Additional info for the logic:
- for removals, copy to temp dir, remove file in temp dir; if 
have a file not in a directory, remove it directly
- for changes/additions, copy to temp dir, write files in temp 
dir; if have a file not in a directory, copy as temp file
- Do local exchange/rename and remove temp dir/file

And use `insert()` instead of `push()` to match `starts_with()`
 when scanning temp files & dirs.

Fixes https://github.com/coreos/bootupd/issues/454

---

filetree: add failpoint when doing exchange
Inspired by https://github.com/coreos/bootupd/pull/669#issuecomment-2220760948
