### PR TITLE
Port to rustix, drop nix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,11 +83,11 @@ dependencies = [
  "libc",
  "libsystemd",
  "log",
- "nix 0.23.2",
  "openat",
  "openat-ext",
  "openssl",
  "os-release",
+ "rustix",
  "serde",
  "serde_json",
  "tempfile",
@@ -699,9 +699,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.4.1",
  "errno",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,11 @@ hex = "0.4.3"
 libc = "^0.2"
 libsystemd = ">= 0.3, < 0.8"
 log = "^0.4"
-nix = ">= 0.22.1, < 0.24.0"
 openat = "0.1.20"
 openat-ext = ">= 0.2.2, < 0.3.0"
 openssl = "^0.10"
 os-release = "0.1.0"
+rustix = { version = "0.38.34", features = ["process", "fs"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 tempfile = "^3.10"

--- a/src/cli/bootupctl.rs
+++ b/src/cli/bootupctl.rs
@@ -142,7 +142,7 @@ fn running_in_systemd() -> bool {
 
 /// Require root permission
 fn require_root_permission() -> Result<()> {
-    if !nix::unistd::Uid::effective().is_root() {
+    if !rustix::process::getuid().is_root() {
         anyhow::bail!("This command requires root privileges")
     }
     Ok(())

--- a/src/util.rs
+++ b/src/util.rs
@@ -67,10 +67,9 @@ pub(crate) fn filenames(dir: &openat::Dir) -> Result<HashSet<String>> {
 }
 
 pub(crate) fn ensure_writable_mount<P: AsRef<Path>>(p: P) -> Result<()> {
-    use nix::sys::statvfs;
     let p = p.as_ref();
-    let stat = statvfs::statvfs(p)?;
-    if !stat.flags().contains(statvfs::FsFlags::ST_RDONLY) {
+    let stat = rustix::fs::statvfs(p)?;
+    if !stat.f_flag.contains(rustix::fs::StatVfsMountFlags::RDONLY) {
         return Ok(());
     }
     let status = std::process::Command::new("mount")


### PR DESCRIPTION
We already have rustix as a dependency; now that we don't use IPC anymore it's trivial to port to rustix. I prefer its API and maintainer.