### PR TITLE
ci: minor updates

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -41,8 +41,6 @@ cosaPod(runAsUser: 0, memory: "4608Mi", cpu: "4") {
   stage("Build FCOS") {
     checkout scm
     unstash 'build'
-    // Fast track https://bodhi.fedoraproject.org/updates/FEDORA-2023-5041615f94
-    shwrap("sudo dnf -y update https://kojipkgs.fedoraproject.org//packages/virtiofsd/1.7.0/5.fc38/x86_64/virtiofsd-1.7.0-5.fc38.x86_64.rpm")
     // Note that like {rpm-,}ostree we want to install to both / and overrides/rootfs
     // because bootupd is used both during the `rpm-ostree compose tree` as well as
     // inside the target operating system.

--- a/tests/e2e-update/e2e-update.sh
+++ b/tests/e2e-update/e2e-update.sh
@@ -80,15 +80,15 @@ undo_manifest_fork() {
 if test -z "${e2e_skip_build:-}"; then
     echo "Building starting image"
     rm -f ${overrides}/rpm/*.rpm
-    # Version from F37 GA
-    add_override grub2-2.06-89.fc38
+    # Version from F39 GA
+    add_override grub2-2.06-100.fc39
     runv cosa build
     prev_image=$(runv cosa meta --image-path qemu)
     create_manifest_fork
     rm -f ${overrides}/rpm/*.rpm
     echo "Building update ostree"
     # Version queued in current updates
-    add_override grub2-2.06-102.fc38
+    add_override grub2-2.06-123.fc40
     mv ${test_tmpdir}/yumrepo/packages/$(arch)/*.rpm ${overrides}/rpm/
     # Only build ostree update
     runv cosa build ostree


### PR DESCRIPTION
- Remove fast track for `virtiofsd` as higher version is installed
- Update `grub2` to newer version in ci testing