### PR TITLE
efi: sync bootentry label with Anaconda

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,7 @@ dependencies = [
  "openat-ext",
  "openssl",
  "os-release",
+ "regex",
  "rustix",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ openat = "0.1.20"
 openat-ext = ">= 0.2.2, < 0.3.0"
 openssl = "^0.10"
 os-release = "0.1.0"
+regex = "1.10.4"
 rustix = { version = "0.38.34", features = ["process", "fs"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"


### PR DESCRIPTION
Read `/etc/system-release` if exists, else get `NAME` from `/etc/os-release`

See https://bugzilla.redhat.com/show_bug.cgi?id=2268505#c24