### PR TITLE
packaging: add a systemd unit to run every boot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ install-grub-static:
 	install -m 644 -D -t ${DESTDIR}$(PREFIX)/lib/bootupd/grub2-static src/grub2/*.cfg
 	install -m 755 -d ${DESTDIR}$(PREFIX)/lib/bootupd/grub2-static/configs.d
 
+install-systemd-unit:
+	install -m 644 -D -t "${DESTDIR}$(PREFIX)/lib/systemd/system/" contrib/packaging/bootupctl-update.service
+
 bin-archive:
 	rm target/inst -rf
 	$(MAKE) install install-grub-static DESTDIR=$$(pwd)/target/inst

--- a/contrib/packaging/bootupctl-update.service
+++ b/contrib/packaging/bootupctl-update.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Update Bootloader on boot
+Documentation=https://github.com/coreos/bootupd
+ConditionPathExists=/dev/disk/by-label/EFI-SYSTEM
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/bootupctl update
+RemainAfterExit=yes
+MountFlags=slave
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/packaging/bootupd.spec
+++ b/contrib/packaging/bootupd.spec
@@ -21,6 +21,7 @@ BuildRequires: cargo
 BuildRequires: git
 BuildRequires: openssl-devel
 BuildRequires: systemd-devel
+BuildRequires: systemd-rpm-macros
 
 %description 
 %{summary}
@@ -31,6 +32,7 @@ BuildRequires: systemd-devel
 %{_bindir}/bootupctl
 %{_libexecdir}/bootupd
 %{_prefix}/lib/bootupd/grub2-static/
+%{_unitdir}/bootupctl-update.service
 
 %prep
 %autosetup -n %{crate}-%{version} -p1 -Sgit
@@ -50,6 +52,7 @@ cargo build --release
 %install
 %make_install INSTALL="install -p -c"
 make install-grub-static DESTDIR=%{?buildroot} INSTALL="%{__install} -p"
+make install-systemd-unit DESTDIR=%{?buildroot} INSTALL="%{__install} -p"
 
 %changelog
 * Tue Oct 18 2022 Colin Walters <walters@verbum.org> - 0.2.8-3


### PR DESCRIPTION
This enables bootloader updates automatically on boot. Note that the service is intentionally not enabled by default, it should be up to the distribution to add a systemd preset if auto-update for the bootloader is desired.

Right now RAID setups are not supported but see [1] for an example in coreos.

[1] https://github.com/coreos/fedora-coreos-config/pull/3042