### PR TITLE
Skip `UEFI` or `BIOS` on none hybrid partition layout

### DIFF
--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -380,11 +380,7 @@ pub(crate) fn print_status(status: &Status) -> Result<()> {
 
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     {
-        let boot_method = if Path::new("/sys/firmware/efi").exists() {
-            "EFI"
-        } else {
-            "BIOS"
-        };
+        let boot_method = if efi::is_efi_booted()? { "EFI" } else { "BIOS" };
         println!("Boot method: {}", boot_method);
     }
 


### PR DESCRIPTION
- When booting with `BIOS` and no `ESP` device detected, skip `UEFI` checking
- When booting with `UEFI` and no `bios_boot` partition found, skip `BIOS` checking

Fixes https://github.com/coreos/bootupd/issues/717