### PR TITLE
bios: Handle empty pttype from lsblk output

### DIFF
--- a/tests/fixtures/example-lsblk-output.json
+++ b/tests/fixtures/example-lsblk-output.json
@@ -1,0 +1,33 @@
+{
+   "blockdevices": [
+      {
+         "path": "/dev/sr0",
+         "pttype": null,
+         "parttypename": null
+      },{
+         "path": "/dev/zram0",
+         "pttype": null,
+         "parttypename": null
+      },{
+         "path": "/dev/vda",
+         "pttype": "gpt",
+         "parttypename": null
+      },{
+         "path": "/dev/vda1",
+         "pttype": "gpt",
+         "parttypename": "EFI System"
+      },{
+         "path": "/dev/vda2",
+         "pttype": "gpt",
+         "parttypename": "Linux extended boot"
+      },{
+         "path": "/dev/vda3",
+         "pttype": "gpt",
+         "parttypename": "Linux filesystem"
+      },{
+         "path": "/dev/mapper/luks-df2d5f95-5725-44dd-83e1-81bc4cdc49b8",
+         "pttype": null,
+         "parttypename": null
+      }
+   ]
+}


### PR DESCRIPTION
zram, sr0 (CD/DVD) and LUKS devices generally don't use partitions, thus don't have a partition table and thus don't have a partition table type so this field may be null.

Fixes: https://github.com/coreos/bootupd/issues/739