### PR TITLE
Release 0.2.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "bootupd"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bootupd"
 description = "Bootloader updater"
 license = "Apache-2.0"
-version = "0.2.23"
+version = "0.2.24"
 authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2021"
 rust-version = "1.75.0"


### PR DESCRIPTION
This is to include https://github.com/coreos/bootupd/pull/740.