### PR TITLE
grub-static-pre.cfg: Update link to preserve coreos-assembler history

### DIFF
--- a/src/grub2/grub-static-pre.cfg
+++ b/src/grub2/grub-static-pre.cfg
@@ -1,4 +1,4 @@
-# This file is copied from https://github.com/coreos/coreos-assembler/blob/main/src/grub.cfg
+# This file is copied from https://github.com/coreos/coreos-assembler/blob/0eb25d1c718c88414c0b9aedd19dc56c09afbda8/src/grub.cfg
 # Changes:
 #   - Dropped Ignition glue, that can be injected into platform.cfg
 # petitboot doesn't support -e and doesn't support an empty path part


### PR DESCRIPTION
- grub.cfg was removed from the main branch in https://github.com/coreos/coreos-assembler/pull/3900
- Updated the link to maintain reference to the file’s origin and history.