### PR TITLE
Disable tests that require creation time on musl

### DIFF
--- a/src/coreos.rs
+++ b/src/coreos.rs
@@ -56,6 +56,8 @@ mod test {
         "ostree-commit": "b2ea6159d6274e1bbbb49aa0ef093eda5d53a75c8a793dbe184f760ed64dc862"
     }"##;
 
+    // Waiting on https://github.com/rust-lang/rust/pull/125692
+    #[cfg(not(target_env = "musl"))]
     #[test]
     fn test_parse_from_root_empty() -> Result<()> {
         // Verify we're a no-op in an empty root
@@ -65,6 +67,8 @@ mod test {
         Ok(())
     }
 
+    // Waiting on https://github.com/rust-lang/rust/pull/125692
+    #[cfg(not(target_env = "musl"))]
     #[test]
     fn test_parse_from_root() -> Result<()> {
         let root: &tempfile::TempDir = &tempfile::tempdir()?;
@@ -77,6 +81,8 @@ mod test {
         Ok(())
     }
 
+    // Waiting on https://github.com/rust-lang/rust/pull/125692
+    #[cfg(not(target_env = "musl"))]
     #[test]
     fn test_parse_from_root_linked() -> Result<()> {
         let root: &tempfile::TempDir = &tempfile::tempdir()?;

--- a/src/filetree.rs
+++ b/src/filetree.rs
@@ -624,6 +624,8 @@ mod tests {
         assert!(!dp.exists(".btmp.b")?);
         Ok(())
     }
+    // Waiting on https://github.com/rust-lang/rust/pull/125692
+    #[cfg(not(target_env = "musl"))]
     #[test]
     fn test_apply_with_file() -> Result<()> {
         let tmpd = tempfile::tempdir()?;


### PR DESCRIPTION
Creation time will only be supported on the musl target once https://github.com/rust-lang/rust/pull/125692 lands.

This MR disables the tests that require creation time for musl.