### PR TITLE
main: Don't use package system to query our own version

### DIFF
--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -8,6 +8,7 @@ use crate::efi;
 use crate::model::{ComponentStatus, ComponentUpdatable, ContentMetadata, SavedState, Status};
 use crate::util;
 use anyhow::{anyhow, Context, Result};
+use clap::crate_version;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
@@ -96,7 +97,12 @@ pub(crate) fn install(
 
     match configs.enabled_with_uuid() {
         Some(uuid) => {
-            let self_meta = crate::packagesystem::query_files("/", ["/usr/bin/bootupctl"])?;
+            let self_bin_meta =
+                std::fs::metadata("/proc/self/exe").context("Querying self meta")?;
+            let self_meta = ContentMetadata {
+                timestamp: self_bin_meta.modified()?.into(),
+                version: crate_version!().into(),
+            };
             state.static_configs = Some(self_meta);
             #[cfg(any(
                 target_arch = "x86_64",


### PR DESCRIPTION
When we were reworking `bootc install` to try to run outside of a container, we hit on the fact that this query required rpm in the *host* context which is conceptually broken.

As part of severing our dependency on rpm (and package systems) in general let's just use our own crate version which we know at compile time.