### PR TITLE
Import GRUB static migration code

### DIFF
--- a/src/cli/bootupctl.rs
+++ b/src/cli/bootupctl.rs
@@ -59,6 +59,12 @@ pub enum CtlVerb {
     AdoptAndUpdate,
     #[clap(name = "validate", about = "Validate system state")]
     Validate,
+    #[clap(
+        name = "migrate-static-grub-config",
+        hide = true,
+        about = "Migrate a system to a static GRUB config"
+    )]
+    MigrateStaticGrubConfig,
 }
 
 #[derive(Debug, Parser)]
@@ -96,6 +102,7 @@ impl CtlCommand {
             CtlVerb::Backend(CtlBackend::Install(opts)) => {
                 super::bootupd::DCommand::run_install(opts)
             }
+            CtlVerb::MigrateStaticGrubConfig => Self::run_migrate_static_grub_config(),
         }
     }
 
@@ -135,6 +142,12 @@ impl CtlCommand {
     fn run_validate() -> Result<()> {
         ensure_running_in_systemd()?;
         bootupd::client_run_validate()
+    }
+
+    /// Runner for `migrate-static-grub-config` verb.
+    fn run_migrate_static_grub_config() -> Result<()> {
+        ensure_running_in_systemd()?;
+        bootupd::client_run_migrate_static_grub_config()
     }
 }
 


### PR DESCRIPTION
migrate-static-grub-config: Add GRUB static migration subcommand

Add a hidden subcommand that migrates existing systems using a dynamic
GRUB config to a static one.

This command is expected to be run after a successful bootloader update.
One way to do that is to add it as a droppin unit config for the
`bootloader-update.service` unit included in this repo:

```
$ cat /usr/lib/systemd/system/bootloader-update.service.d/migrate-static-grub-config.conf
[Service]
ExecStart=/usr/bin/bootupctl migrate-static-grub-config
```

This will be used on Atomic Desktops & IoT systems to migrate systems to
a static GRUB config before enabling composefs as GRUB curently does not
interact well with it [1].

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2308594

See: https://gitlab.com/fedora/ostree/sig/-/issues/35
See: https://pagure.io/workstation-ostree-config/pull-request/591
See: https://fedoraproject.org/wiki/Changes/ComposefsAtomicDesktops
Fixes: https://github.com/coreos/bootupd/issues/789