### PR TITLE
status: support running in a container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: build
         run: sudo podman build -t localhost/bootupd:latest -f ci/Containerfile.c9s .
+      - name: bootupctl status in container
+        run: |
+          set -xeuo pipefail
+          output=$(sudo podman run --rm -ti localhost/bootupd:latest bootupctl status | tr -d '\r')
+          [ "Available components: BIOS EFI" == "${output}" ]
       - name: bootc install to disk
         run: |
           set -xeuo pipefail

--- a/src/util.rs
+++ b/src/util.rs
@@ -96,3 +96,22 @@ pub(crate) fn cmd_output(cmd: &mut Command) -> Result<String> {
     String::from_utf8(result.stdout)
         .with_context(|| format!("decoding as UTF-8 output of `{:#?}`", cmd))
 }
+
+/// Copy from https://github.com/containers/bootc/blob/main/ostree-ext/src/container_utils.rs#L20
+/// Attempts to detect if the current process is running inside a container.
+/// This looks for the `container` environment variable or the presence
+/// of Docker or podman's more generic `/run/.containerenv`.
+/// This is a best-effort function, as there is not a 100% reliable way
+/// to determine this.
+pub fn running_in_container() -> bool {
+    if std::env::var_os("container").is_some() {
+        return true;
+    }
+    // https://stackoverflow.com/questions/20010199/how-to-determine-if-a-process-runs-inside-lxc-docker
+    for p in ["/run/.containerenv", "/.dockerenv"] {
+        if Path::new(p).exists() {
+            return true;
+        }
+    }
+    false
+}


### PR DESCRIPTION
The output in container is like:
```
bash-5.2# bootupctl status
Available: BIOS EFI
```

Fixes: https://github.com/coreos/bootupd/issues/788