### PR TITLE
status: support `bootupctl status --json` in container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
           set -xeuo pipefail
           output=$(sudo podman run --rm -ti localhost/bootupd:latest bootupctl status | tr -d '\r')
           [ "Available components: BIOS EFI" == "${output}" ]
+          output=$(sudo podman run --rm -ti localhost/bootupd:latest bootupctl status --json)
+          [ '{"components":["BIOS","EFI"]}' == "${output}" ]
       - name: bootc install to disk
         run: |
           set -xeuo pipefail


### PR DESCRIPTION
The output like:
```
bash-5.2# bootupctl status --json
{"components":["BIOS","EFI"]}
```
Fixes: https://github.com/coreos/bootupd/issues/794