### PR TITLE
src: Fix 'contains_key' clippy lints

### DIFF
--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -249,7 +249,7 @@ pub(crate) fn adopt_and_update(name: &str) -> Result<ContentMetadata> {
     let sysroot = openat::Dir::open("/")?;
     let mut state = SavedState::load_from_disk("/")?.unwrap_or_default();
     let component = component::new_from_name(name)?;
-    if state.installed.get(name).is_some() {
+    if state.installed.contains_key(name) {
         anyhow::bail!("Component {} is already installed", name);
     };
 

--- a/src/filetree.rs
+++ b/src/filetree.rs
@@ -184,7 +184,7 @@ impl FileTree {
         }
         if check_additions {
             for k in updated.children.keys() {
-                if self.children.get(k).is_some() {
+                if self.children.contains_key(k) {
                     continue;
                 }
                 additions.insert(k.clone());


### PR DESCRIPTION
```
warning: unnecessary use of `get(k).is_some()`
   --> src/filetree.rs:187:34
    |
187 |                 if self.children.get(k).is_some() {
    |                                  ^^^^^^^^^^^^^^^^ help: replace it with: `contains_key(k)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_get_then_check
    = note: `#[warn(clippy::unnecessary_get_then_check)]` on by default
```