### PR TITLE
Delay being killed on reboot/poweroff

### DIFF
--- a/contrib/packaging/bootloader-update.service
+++ b/contrib/packaging/bootloader-update.service
@@ -6,7 +6,12 @@ Documentation=https://github.com/coreos/bootupd
 Type=oneshot
 ExecStart=/usr/bin/bootupctl update
 RemainAfterExit=yes
+PrivateNetwork=yes
+ProtectHome=yes
 MountFlags=slave
+# inhibit locks are ignored by reboot/poweroff (need to use systemctl)
+# so just delay being killed as much as possible
+KillSignal=SIGCONT
 
 [Install]
 WantedBy=multi-user.target

--- a/src/cli/bootupctl.rs
+++ b/src/cli/bootupctl.rs
@@ -15,6 +15,8 @@ static SYSTEMD_ARGS_BOOTUPD: &[&str] = &[
     "ProtectHome=yes",
     "--property",
     "MountFlags=slave",
+    "--property",
+    "KillSignal=SIGCONT",
     "--pipe",
 ];
 


### PR DESCRIPTION
Setting KillSignal=SIGCONT is a hack, but it gives us DefaultTimeoutStopSec before being killed (45s on Fedora, 90s on EL9).
The proper systemd way would be to use inhibit locks but they are ignored by reboot/poweroff commands, ie you need the systemctl reboot/poweroff variants, and just using systemd-inhibit makes all the logs starts with systemd-inhibit instead of bootupctl.