### PR TITLE
Catch and ignore SIGTERM during update operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_json",
+ "signal-hook-registry",
  "tempfile",
  "walkdir",
  "widestring",
@@ -897,6 +898,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ serde_json = "^1.0"
 tempfile = "^3.14"
 widestring = "1.1.0"
 walkdir = "2.3.2"
+signal-hook-registry = "1.4.2"
 
 [profile.release]
 # We assume we're being delivered via e.g. RPM which supports split debuginfo

--- a/contrib/packaging/bootloader-update.service
+++ b/contrib/packaging/bootloader-update.service
@@ -6,6 +6,10 @@ Documentation=https://github.com/coreos/bootupd
 Type=oneshot
 ExecStart=/usr/bin/bootupctl update
 RemainAfterExit=yes
+# Keep this stuff in sync with SYSTEMD_ARGS_BOOTUPD in general
+PrivateNetwork=yes
+ProtectHome=yes
+KillMode=mixed
 MountFlags=slave
 
 [Install]

--- a/src/cli/bootupctl.rs
+++ b/src/cli/bootupctl.rs
@@ -13,6 +13,10 @@ static SYSTEMD_ARGS_BOOTUPD: &[&str] = &[
     "PrivateNetwork=yes",
     "--property",
     "ProtectHome=yes",
+    // While only our main process during update catches SIGTERM, we don't
+    // want systemd to send it to other processes.
+    "--property",
+    "KillMode=mixed",
     "--property",
     "MountFlags=slave",
     "--pipe",


### PR DESCRIPTION
Since our updates are non-transactional in general, we should at least be robust against some concurrent invocation of e.g. `reboot`.

Replaces: https://github.com/coreos/bootupd/pull/811