### PR TITLE
Add `blockdev` and update bios.rs

### DIFF
--- a/src/bios.rs
+++ b/src/bios.rs
@@ -1,68 +1,22 @@
 use std::io::prelude::*;
+use std::os::unix::io::AsRawFd;
 use std::path::Path;
 use std::process::Command;
 
+use crate::blockdev;
 use crate::component::*;
 use crate::model::*;
 use crate::packagesystem;
-use anyhow::{bail, Result};
 
-use crate::util;
-use serde::{Deserialize, Serialize};
+use anyhow::{bail, Result};
 
 // grub2-install file path
 pub(crate) const GRUB_BIN: &str = "usr/sbin/grub2-install";
-
-#[derive(Serialize, Deserialize, Debug)]
-struct BlockDevice {
-    path: String,
-    pttype: Option<String>,
-    parttypename: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct Devices {
-    blockdevices: Vec<BlockDevice>,
-}
 
 #[derive(Default)]
 pub(crate) struct Bios {}
 
 impl Bios {
-    // get target device for running update
-    fn get_device(&self) -> Result<String> {
-        let mut cmd: Command;
-        #[cfg(target_arch = "x86_64")]
-        {
-            // find /boot partition
-            cmd = Command::new("findmnt");
-            cmd.arg("--noheadings")
-                .arg("--nofsroot")
-                .arg("--output")
-                .arg("SOURCE")
-                .arg("/boot");
-            let partition = util::cmd_output(&mut cmd)?;
-
-            // lsblk to find parent device
-            cmd = Command::new("lsblk");
-            cmd.arg("--paths")
-                .arg("--noheadings")
-                .arg("--output")
-                .arg("PKNAME")
-                .arg(partition.trim());
-        }
-
-        #[cfg(target_arch = "powerpc64")]
-        {
-            // get PowerPC-PReP-boot partition
-            cmd = Command::new("realpath");
-            cmd.arg("/dev/disk/by-partlabel/PowerPC-PReP-boot");
-        }
-
-        let device = util::cmd_output(&mut cmd)?;
-        Ok(device)
-    }
-
     // Return `true` if grub2-modules installed
     fn check_grub_modules(&self) -> Result<bool> {
         let usr_path = Path::new("/usr/lib/grub");
@@ -114,38 +68,17 @@ impl Bios {
         Ok(())
     }
 
-    // check bios_boot partition on gpt type disk
-    fn get_bios_boot_partition(&self) -> Result<Option<String>> {
-        let target = self.get_device()?;
-        // lsblk to list children with bios_boot
-        let output = Command::new("lsblk")
-            .args([
-                "--json",
-                "--output",
-                "PATH,PTTYPE,PARTTYPENAME",
-                target.trim(),
-            ])
-            .output()?;
-        if !output.status.success() {
-            std::io::stderr().write_all(&output.stderr)?;
-            bail!("Failed to run lsblk");
-        }
-
-        let output = String::from_utf8(output.stdout)?;
-        // Parse the JSON string into the `Devices` struct
-        let Ok(devices) = serde_json::from_str::<Devices>(&output) else {
-            bail!("Could not deserialize JSON output from lsblk");
-        };
-
-        // Find the device with the parttypename "BIOS boot"
-        for device in devices.blockdevices {
-            if let Some(parttypename) = &device.parttypename {
-                if parttypename == "BIOS boot" && device.pttype.as_deref() == Some("gpt") {
-                    return Ok(Some(device.path));
-                }
+    // check bios_boot part on gpt type disk
+    fn get_bios_boot_partition(&self) -> Option<String> {
+        match blockdev::get_single_device("/") {
+            Ok(device) => {
+                let bios_boot_part =
+                    blockdev::get_bios_boot_partition(&device).expect("get bios_boot part");
+                return bios_boot_part;
             }
+            Err(e) => log::warn!("Get error: {}", e),
         }
-        Ok(None)
+        None
     }
 }
 
@@ -187,7 +120,7 @@ impl Component for Bios {
 
     fn query_adopt(&self) -> Result<Option<Adoptable>> {
         #[cfg(target_arch = "x86_64")]
-        if crate::efi::is_efi_booted()? && self.get_bios_boot_partition()?.is_none() {
+        if crate::efi::is_efi_booted()? && self.get_bios_boot_partition().is_none() {
             log::debug!("Skip BIOS adopt");
             return Ok(None);
         }
@@ -199,9 +132,10 @@ impl Component for Bios {
             anyhow::bail!("Failed to find adoptable system")
         };
 
-        let device = self.get_device()?;
-        let device = device.trim();
-        self.run_grub_install("/", device)?;
+        let target_root = "/";
+        let device = blockdev::get_single_device(&target_root)?;
+        self.run_grub_install(target_root, &device)?;
+        log::debug!("Install grub2 on {device}");
         Ok(InstalledContent {
             meta: update.clone(),
             filetree: None,
@@ -215,9 +149,10 @@ impl Component for Bios {
 
     fn run_update(&self, sysroot: &openat::Dir, _: &InstalledContent) -> Result<InstalledContent> {
         let updatemeta = self.query_update(sysroot)?.expect("update available");
-        let device = self.get_device()?;
-        let device = device.trim();
-        self.run_grub_install("/", device)?;
+        let dest_root = format!("/proc/self/fd/{}", sysroot.as_raw_fd());
+        let device = blockdev::get_single_device(&dest_root)?;
+        self.run_grub_install(&dest_root, &device)?;
+        log::debug!("Install grub modules on {device}");
 
         let adopted_from = None;
         Ok(InstalledContent {
@@ -233,20 +168,5 @@ impl Component for Bios {
 
     fn get_efi_vendor(&self, _: &openat::Dir) -> Result<Option<String>> {
         Ok(None)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_deserialize_lsblk_output() {
-        let data = include_str!("../tests/fixtures/example-lsblk-output.json");
-        let devices: Devices = serde_json::from_str(&data).expect("JSON was not well-formatted");
-        assert_eq!(devices.blockdevices.len(), 7);
-        assert_eq!(devices.blockdevices[0].path, "/dev/sr0");
-        assert!(devices.blockdevices[0].pttype.is_none());
-        assert!(devices.blockdevices[0].parttypename.is_none());
     }
 }

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -169,6 +169,7 @@ pub fn get_esp_partition(device: &str) -> Result<Option<String>> {
 }
 
 /// Find all ESP partitions on the devices with mountpoint boot
+#[allow(dead_code)]
 pub fn find_colocated_esps<P: AsRef<Path>>(target_root: P) -> Result<Vec<String>> {
     // first, get the parent device
     let devices = get_devices(&target_root).with_context(|| "while looking for colocated ESPs")?;
@@ -198,6 +199,7 @@ pub fn get_bios_boot_partition(device: &str) -> Result<Option<String>> {
 }
 
 /// Find all bios_boot partitions on the devices with mountpoint boot
+#[allow(dead_code)]
 pub fn find_colocated_bios_boot<P: AsRef<Path>>(target_root: P) -> Result<Vec<String>> {
     // first, get the parent device
     let devices =

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -1,0 +1,231 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Command;
+use std::sync::OnceLock;
+
+use crate::util;
+use anyhow::{bail, Context, Result};
+use bootc_utils::CommandRunExt;
+use fn_error_context::context;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+struct BlockDevices {
+    blockdevices: Vec<Device>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Device {
+    path: String,
+    pttype: Option<String>,
+    parttype: Option<String>,
+    parttypename: Option<String>,
+}
+
+impl Device {
+    pub(crate) fn is_esp_part(&self) -> bool {
+        const ESP_TYPE_GUID: &str = "c12a7328-f81f-11d2-ba4b-00a0c93ec93b";
+        if let Some(parttype) = &self.parttype {
+            if parttype.to_lowercase() == ESP_TYPE_GUID {
+                return true;
+            }
+        }
+        false
+    }
+
+    pub(crate) fn is_bios_boot_part(&self) -> bool {
+        const BIOS_BOOT_TYPE_GUID: &str = "21686148-6449-6e6f-744e-656564454649";
+        if let Some(parttype) = &self.parttype {
+            if parttype.to_lowercase() == BIOS_BOOT_TYPE_GUID
+                && self.pttype.as_deref() == Some("gpt")
+            {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+/// Parse key-value pairs from lsblk --pairs.
+/// Newer versions of lsblk support JSON but the one in CentOS 7 doesn't.
+fn split_lsblk_line(line: &str) -> HashMap<String, String> {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    let regex = REGEX.get_or_init(|| Regex::new(r#"([A-Z-_]+)="([^"]+)""#).unwrap());
+    let mut fields: HashMap<String, String> = HashMap::new();
+    for cap in regex.captures_iter(line) {
+        fields.insert(cap[1].to_string(), cap[2].to_string());
+    }
+    fields
+}
+
+/// This is a bit fuzzy, but... this function will return every block device in the parent
+/// hierarchy of `device` capable of containing other partitions. So e.g. parent devices of type
+/// "part" doesn't match, but "disk" and "mpath" does.
+pub(crate) fn find_parent_devices(device: &str) -> Result<Vec<String>> {
+    let mut cmd = Command::new("lsblk");
+    // Older lsblk, e.g. in CentOS 7.6, doesn't support PATH, but --paths option
+    cmd.arg("--pairs")
+        .arg("--paths")
+        .arg("--inverse")
+        .arg("--output")
+        .arg("NAME,TYPE")
+        .arg(device);
+    let output = util::cmd_output(&mut cmd)?;
+    let mut parents = Vec::new();
+    // skip first line, which is the device itself
+    for line in output.lines().skip(1) {
+        let dev = split_lsblk_line(line);
+        let name = dev
+            .get("NAME")
+            .with_context(|| format!("device in hierarchy of {device} missing NAME"))?;
+        let kind = dev
+            .get("TYPE")
+            .with_context(|| format!("device in hierarchy of {device} missing TYPE"))?;
+        if kind == "disk" {
+            parents.push(name.clone());
+        } else if kind == "mpath" {
+            parents.push(name.clone());
+            // we don't need to know what disks back the multipath
+            break;
+        }
+    }
+    Ok(parents)
+}
+
+#[context("get parent devices from mountpoint boot")]
+pub fn get_devices<P: AsRef<Path>>(target_root: P) -> Result<Vec<String>> {
+    let target_root = target_root.as_ref();
+    let bootdir = target_root.join("boot");
+    if !bootdir.exists() {
+        bail!("{} does not exist", bootdir.display());
+    }
+    let bootdir = openat::Dir::open(&bootdir)?;
+    // Run findmnt to get the source path of mount point boot
+    let fsinfo = crate::filesystem::inspect_filesystem(&bootdir, ".")?;
+    // Find the parent devices of the source path
+    let parent_devices = find_parent_devices(&fsinfo.source)
+        .with_context(|| format!("while looking for backing devices of {}", fsinfo.source))?;
+    log::debug!("Find parent devices: {parent_devices:?}");
+    Ok(parent_devices)
+}
+
+// Get single device for the target root
+pub fn get_single_device<P: AsRef<Path>>(target_root: P) -> Result<String> {
+    let target_root = target_root.as_ref();
+    let bootdir = target_root.join("boot");
+    if !bootdir.exists() {
+        bail!("{} does not exist", bootdir.display());
+    }
+    let bootdir = openat::Dir::open(&bootdir)?;
+    // Run findmnt to get the source path of mount point boot
+    let fsinfo = crate::filesystem::inspect_filesystem(&bootdir, ".")?;
+    // Find the single parent device of the source path
+    let backing_device = {
+        let mut dev = fsinfo.source;
+        loop {
+            log::debug!("Finding parents for {dev}");
+            let mut parents = find_parent_devices(&dev)?.into_iter();
+            let Some(parent) = parents.next() else {
+                break;
+            };
+            log::debug!("Get {dev} parent: {parent}");
+            if let Some(next) = parents.next() {
+                anyhow::bail!(
+                    "Found multiple parent devices {parent} and {next}; not currently supported"
+                );
+            }
+            dev = parent;
+        }
+        dev
+    };
+    Ok(backing_device)
+}
+
+#[context("Listing device {device}")]
+fn list_dev(device: &str) -> Result<BlockDevices> {
+    let devs: BlockDevices = Command::new("lsblk")
+        .args([
+            "--json",
+            "--output",
+            "PATH,PTTYPE,PARTTYPE,PARTTYPENAME",
+            device,
+        ])
+        .run_and_parse_json()?;
+    Ok(devs)
+}
+
+/// Find esp partition on the same device
+pub fn get_esp_partition(device: &str) -> Result<Option<String>> {
+    let dev = list_dev(&device)?;
+    // Find the ESP part on the disk
+    for part in dev.blockdevices {
+        if part.is_esp_part() {
+            return Ok(Some(part.path));
+        }
+    }
+    log::debug!("Not found any esp partition");
+    Ok(None)
+}
+
+/// Find all ESP partitions on the devices with mountpoint boot
+pub fn find_colocated_esps<P: AsRef<Path>>(target_root: P) -> Result<Vec<String>> {
+    // first, get the parent device
+    let devices = get_devices(&target_root).with_context(|| "while looking for colocated ESPs")?;
+
+    // now, look for all ESPs on those devices
+    let mut esps = Vec::new();
+    for device in devices {
+        if let Some(esp) = get_esp_partition(&device)? {
+            esps.push(esp)
+        }
+    }
+    log::debug!("Find esp partitions: {esps:?}");
+    Ok(esps)
+}
+
+/// Find bios_boot partition on the same device
+pub fn get_bios_boot_partition(device: &str) -> Result<Option<String>> {
+    let dev = list_dev(&device)?;
+    // Find the BIOS BOOT part on the disk
+    for part in dev.blockdevices {
+        if part.is_bios_boot_part() {
+            return Ok(Some(part.path));
+        }
+    }
+    log::debug!("Not found any bios_boot partition");
+    Ok(None)
+}
+
+/// Find all bios_boot partitions on the devices with mountpoint boot
+pub fn find_colocated_bios_boot<P: AsRef<Path>>(target_root: P) -> Result<Vec<String>> {
+    // first, get the parent device
+    let devices =
+        get_devices(&target_root).with_context(|| "looking for colocated bios_boot parts")?;
+
+    // now, look for all bios_boot parts on those devices
+    let mut bios_boots = Vec::new();
+    for device in devices {
+        if let Some(bios) = get_bios_boot_partition(&device)? {
+            bios_boots.push(bios)
+        }
+    }
+    log::debug!("Find bios_boot partitions: {bios_boots:?}");
+    Ok(bios_boots)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_lsblk_output() {
+        let data = include_str!("../tests/fixtures/example-lsblk-output.json");
+        let devices: BlockDevices =
+            serde_json::from_str(&data).expect("JSON was not well-formatted");
+        assert_eq!(devices.blockdevices.len(), 7);
+        assert_eq!(devices.blockdevices[0].path, "/dev/sr0");
+        assert!(devices.blockdevices[0].pttype.is_none());
+        assert!(devices.blockdevices[0].parttypename.is_none());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ Refs:
 mod backend;
 #[cfg(any(target_arch = "x86_64", target_arch = "powerpc64"))]
 mod bios;
+mod blockdev;
 mod bootupd;
 mod cli;
 mod component;


### PR DESCRIPTION
Prep for https://github.com/coreos/bootupd/issues/132

---
Add `bootc-blockdev` and local crate `blockdev`
See https://github.com/containers/bootc/pull/1050

---
blockdev.rs: Add `#[allow(dead_code)]` for the unused functions

---
bios.rs: update functions to use blockdev