### PR TITLE
Add `bootc-blockdev` and local mod `blockdev`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "blockdev"
+version = "0.0.0"
+source = "git+https://github.com/containers/bootc?rev=9a586935e3c88a3802ea4308b0ec364b6448c59e#9a586935e3c88a3802ea4308b0ec364b6448c59e"
+dependencies = [
+ "anyhow",
+ "bootc-utils",
+ "camino",
+ "fn-error-context",
+ "regex",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
 name = "bootc-utils"
 version = "0.0.0"
-source = "git+https://github.com/containers/bootc#e8bb9f748fdfeb5164667046b3c6678c619ad46c"
+source = "git+https://github.com/containers/bootc?rev=9a586935e3c88a3802ea4308b0ec364b6448c59e#9a586935e3c88a3802ea4308b0ec364b6448c59e"
 dependencies = [
  "anyhow",
  "rustix",
@@ -173,6 +188,7 @@ version = "0.2.26"
 dependencies = [
  "anyhow",
  "bincode",
+ "blockdev",
  "bootc-utils",
  "camino",
  "cap-std-ext",
@@ -217,6 +233,9 @@ name = "camino"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cap-primitives"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3.2"
-bootc-utils = { git = "https://github.com/containers/bootc", commit = "e8bb9f748fdfeb5164667046b3c6678c619ad46c" }
+bootc-blockdev = { git = "https://github.com/containers/bootc", rev = "9a586935e3c88a3802ea4308b0ec364b6448c59e", package = "blockdev" }
+bootc-utils = { git = "https://github.com/containers/bootc", rev = "9a586935e3c88a3802ea4308b0ec364b6448c59e" }
 cap-std-ext = "4.0.4"
 camino = "1.1.9"
 chrono = { version = "0.4.39", features = ["serde"] }

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -37,6 +37,7 @@ pub fn get_single_device<P: AsRef<Path>>(target_root: P) -> Result<String> {
 
 /// Find esp partition on the same device
 /// using sfdisk to get partitiontable
+#[allow(dead_code)]
 pub fn get_esp_partition(device: &str) -> Result<Option<String>> {
     const ESP_TYPE_GUID: &str = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B";
     let device_info: PartitionTable = bootc_blockdev::partitions_of(Utf8Path::new(device))?;
@@ -51,6 +52,7 @@ pub fn get_esp_partition(device: &str) -> Result<Option<String>> {
 }
 
 /// Find all ESP partitions on the devices with mountpoint boot
+#[allow(dead_code)]
 pub fn find_colocated_esps<P: AsRef<Path>>(target_root: P) -> Result<Vec<String>> {
     // first, get the parent device
     let devices = get_devices(&target_root).with_context(|| "while looking for colocated ESPs")?;
@@ -81,6 +83,7 @@ pub fn get_bios_boot_partition(device: &str) -> Result<Option<String>> {
 }
 
 /// Find all bios_boot partitions on the devices with mountpoint boot
+#[allow(dead_code)]
 pub fn find_colocated_bios_boot<P: AsRef<Path>>(target_root: P) -> Result<Vec<String>> {
     // first, get the parent device
     let devices =

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -2,8 +2,8 @@ use camino::Utf8Path;
 use std::path::Path;
 
 use anyhow::{bail, Context, Result};
-use fn_error_context::context;
 use bootc_blockdev::PartitionTable;
+use fn_error_context::context;
 
 #[context("get parent devices from mount point boot")]
 pub fn get_devices<P: AsRef<Path>>(target_root: P) -> Result<Vec<String>> {
@@ -26,15 +26,11 @@ pub fn get_devices<P: AsRef<Path>>(target_root: P) -> Result<Vec<String>> {
 pub fn get_single_device<P: AsRef<Path>>(target_root: P) -> Result<String> {
     let mut devices = get_devices(&target_root)?.into_iter();
     let Some(parent) = devices.next() else {
-        anyhow::bail!(
-            "Failed to find parent device"
-        );
+        anyhow::bail!("Failed to find parent device");
     };
 
     if let Some(next) = devices.next() {
-        anyhow::bail!(
-            "Found multiple parent devices {parent} and {next}; not currently supported"
-        );
+        anyhow::bail!("Found multiple parent devices {parent} and {next}; not currently supported");
     }
     Ok(parent)
 }
@@ -48,10 +44,9 @@ pub fn get_esp_partition(device: &str) -> Result<Option<String>> {
         .partitions
         .into_iter()
         .find(|p| p.parttype.as_str() == ESP_TYPE_GUID);
-    if esp.is_some() {
-        return Ok(Some(esp.unwrap().node));
+    if let Some(esp) = esp {
+        return Ok(Some(esp.node));
     }
-    log::debug!("Not found any esp partition");
     Ok(None)
 }
 
@@ -79,8 +74,8 @@ pub fn get_bios_boot_partition(device: &str) -> Result<Option<String>> {
         .partitions
         .into_iter()
         .find(|p| p.parttype.as_str() == BIOS_BOOT_TYPE_GUID);
-    if bios_boot.is_some() {
-        return Ok(Some(bios_boot.unwrap().node));
+    if let Some(bios_boot) = bios_boot {
+        return Ok(Some(bios_boot.node));
     }
     Ok(None)
 }

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -1,0 +1,103 @@
+use camino::Utf8Path;
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use fn_error_context::context;
+use bootc_blockdev::PartitionTable;
+
+#[context("get parent devices from mount point boot")]
+pub fn get_devices<P: AsRef<Path>>(target_root: P) -> Result<Vec<String>> {
+    let target_root = target_root.as_ref();
+    let bootdir = target_root.join("boot");
+    if !bootdir.exists() {
+        bail!("{} does not exist", bootdir.display());
+    }
+    let bootdir = openat::Dir::open(&bootdir)?;
+    // Run findmnt to get the source path of mount point boot
+    let fsinfo = crate::filesystem::inspect_filesystem(&bootdir, ".")?;
+    // Find the parent devices of the source path
+    let parent_devices = bootc_blockdev::find_parent_devices(&fsinfo.source)
+        .with_context(|| format!("while looking for backing devices of {}", fsinfo.source))?;
+    log::debug!("Find parent devices: {parent_devices:?}");
+    Ok(parent_devices)
+}
+
+// Get single device for the target root
+pub fn get_single_device<P: AsRef<Path>>(target_root: P) -> Result<String> {
+    let mut devices = get_devices(&target_root)?.into_iter();
+    let Some(parent) = devices.next() else {
+        anyhow::bail!(
+            "Failed to find parent device"
+        );
+    };
+
+    if let Some(next) = devices.next() {
+        anyhow::bail!(
+            "Found multiple parent devices {parent} and {next}; not currently supported"
+        );
+    }
+    Ok(parent)
+}
+
+/// Find esp partition on the same device
+/// using sfdisk to get partitiontable
+pub fn get_esp_partition(device: &str) -> Result<Option<String>> {
+    const ESP_TYPE_GUID: &str = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B";
+    let device_info: PartitionTable = bootc_blockdev::partitions_of(Utf8Path::new(device))?;
+    let esp = device_info
+        .partitions
+        .into_iter()
+        .find(|p| p.parttype.as_str() == ESP_TYPE_GUID);
+    if esp.is_some() {
+        return Ok(Some(esp.unwrap().node));
+    }
+    log::debug!("Not found any esp partition");
+    Ok(None)
+}
+
+/// Find all ESP partitions on the devices with mountpoint boot
+pub fn find_colocated_esps<P: AsRef<Path>>(target_root: P) -> Result<Vec<String>> {
+    // first, get the parent device
+    let devices = get_devices(&target_root).with_context(|| "while looking for colocated ESPs")?;
+
+    // now, look for all ESPs on those devices
+    let mut esps = Vec::new();
+    for device in devices {
+        if let Some(esp) = get_esp_partition(&device)? {
+            esps.push(esp)
+        }
+    }
+    log::debug!("Find esp partitions: {esps:?}");
+    Ok(esps)
+}
+
+/// Find bios_boot partition on the same device
+pub fn get_bios_boot_partition(device: &str) -> Result<Option<String>> {
+    const BIOS_BOOT_TYPE_GUID: &str = "21686148-6449-6E6F-744E-656564454649";
+    let device_info = bootc_blockdev::partitions_of(Utf8Path::new(device))?;
+    let bios_boot = device_info
+        .partitions
+        .into_iter()
+        .find(|p| p.parttype.as_str() == BIOS_BOOT_TYPE_GUID);
+    if bios_boot.is_some() {
+        return Ok(Some(bios_boot.unwrap().node));
+    }
+    Ok(None)
+}
+
+/// Find all bios_boot partitions on the devices with mountpoint boot
+pub fn find_colocated_bios_boot<P: AsRef<Path>>(target_root: P) -> Result<Vec<String>> {
+    // first, get the parent device
+    let devices =
+        get_devices(&target_root).with_context(|| "looking for colocated bios_boot parts")?;
+
+    // now, look for all bios_boot parts on those devices
+    let mut bios_boots = Vec::new();
+    for device in devices {
+        if let Some(bios) = get_bios_boot_partition(&device)? {
+            bios_boots.push(bios)
+        }
+    }
+    log::debug!("Find bios_boot partitions: {bios_boots:?}");
+    Ok(bios_boots)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ Refs:
 mod backend;
 #[cfg(any(target_arch = "x86_64", target_arch = "powerpc64"))]
 mod bios;
+mod blockdev;
 mod bootupd;
 mod cli;
 mod component;


### PR DESCRIPTION
Prep for https://github.com/coreos/bootupd/issues/132

---
Add `bootc-blockdev` and local crate `blockdev`
See https://github.com/containers/bootc/pull/1050 & https://github.com/coreos/bootupd/pull/820#discussion_r1922629422

---
blockdev.rs: Add `#[allow(dead_code)]` for the unused functions

---
bios.rs: update functions to use blockdev