### PR TITLE
contrib/packaging/spec: Sync with Fedora changes

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   crossarch-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Build on ${{ matrix.arch }}
 
     strategy:


### PR DESCRIPTION
github/workflows/cross: Use ubuntu-22.04 runners

---

contrib/packaging/spec: Sync with Fedora changes