### PR TITLE
Drop dbg

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ Refs:
 #![deny(unused_must_use)]
 // The style lints are more annoying than useful
 #![allow(clippy::style)]
+#![deny(clippy::dbg_macro)]
 
 mod backend;
 #[cfg(any(target_arch = "x86_64", target_arch = "powerpc64"))]

--- a/src/ostreeutil.rs
+++ b/src/ostreeutil.rs
@@ -58,7 +58,6 @@ pub(crate) fn rpm_cmd<P: AsRef<Path>>(sysroot: P) -> Result<std::process::Comman
         break;
     }
     if let Some(arg) = arg {
-        dbg!("found", &arg);
         debug!("Using dbpath {arg:?}");
         c.arg(arg);
     } else {


### PR DESCRIPTION
rpm_cmd: Drop leftover dbg!

Oops.

---

Deny `clippy::dbg_macro`

So we don't get more `dbg!` sneaking in.

Signed-off-by: Colin Walters <walters@verbum.org>

---