### PR TITLE
Rework vendoring

### DIFF
--- a/contrib/packaging/bootupd.spec
+++ b/contrib/packaging/bootupd.spec
@@ -2,14 +2,14 @@
 
 %global crate bootupd
 
-Name:           bootupd
+Name:           rust-%{crate}
 Version:        0.2.9
 Release:        1%{?dist}
 Summary:        Bootloader updater
 
 License:        Apache-2.0
 URL:            https://github.com/coreos/bootupd
-Source0:        %{url}/releases/download/v%{version}/bootupd-%{version}.crate
+Source0:        %{url}/releases/download/v%{version}/bootupd-%{version}.tar.zstd
 Source1:        %{url}/releases/download/v%{version}/bootupd-%{version}-vendor.tar.zstd
 ExcludeArch:    %{ix86}
 
@@ -54,7 +54,7 @@ License:        Apache-2.0 AND (Apache-2.0 WITH LLVM-exception) AND BSD-3-Clause
 %{_unitdir}/bootloader-update.service
 
 %prep
-%autosetup -n %{crate}-%{version} -p1 -Sgit
+%autosetup -n %{crate}-%{version} -p1 -Sgit -a1
 # Default -v vendor config doesn't support non-crates.io deps (i.e. git)
 cp .cargo/vendor-config.toml .
 %cargo_prep -N

--- a/contrib/packaging/bootupd.spec
+++ b/contrib/packaging/bootupd.spec
@@ -55,19 +55,17 @@ License:        Apache-2.0 AND (Apache-2.0 WITH LLVM-exception) AND BSD-3-Clause
 
 %prep
 %autosetup -n %{crate}-%{version} -p1 -Sgit
-tar -xv -f %{SOURCE1}
-mkdir -p .cargo
-cat >.cargo/config << EOF
-[source.crates-io]
-replace-with = "vendored-sources"
-
-[source.vendored-sources]
-directory = "vendor"
-EOF
+# Default -v vendor config doesn't support non-crates.io deps (i.e. git)
+cp .cargo/vendor-config.toml .
+%cargo_prep -N
+cat vendor-config.toml >> .cargo/config.toml
+rm vendor-config.toml
 
 %build
 %cargo_build
 %cargo_vendor_manifest
+# https://pagure.io/fedora-rust/rust-packaging/issue/33
+sed -i -e '/https:\/\//d' cargo-vendor.txt
 %cargo_license_summary
 %{cargo_license} > LICENSE.dependencies
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.68"
 camino = "1.0"
-chrono = { version = "0.4.23", default_features = false, features = ["std"] }
+chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 fn-error-context = "0.2.0"
 tempfile = "3.3"
 xshell = { version = "0.2" }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,5 +10,6 @@ anyhow = "1.0.68"
 camino = "1.0"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 fn-error-context = "0.2.0"
+toml = "0.8"
 tempfile = "3.3"
 xshell = { version = "0.2" }


### PR DESCRIPTION
xtask: Fix deprecated `default_features`

cargo warns about this.

---

xtask: Sync with bootc

In particular now that we have a `git` dependency, this turns
out to reveal some deficiencies in how e.g. the Fedora RPM
vendoring support works.

Sync the code from https://github.com/containers/bootc/pull/1068/commits/58fa21e54fa6868d5a266072b822454536398ef9

---

contrib/rpm: Sync vendor config from bootc

---

contrib/rpm: Two more fixes

- Use `rust-%{crate}` for name because that's what Fedora
  does; the previous spec file sync was just broken
- Use a source archive generated from git, not a `.crate`; we
  will stop publishing to crates.io.

Signed-off-by: Colin Walters <walters@verbum.org>

---