### PR TITLE
contrib/packaging/bootupd.spec: keep ix86 for c9s

### DIFF
--- a/contrib/packaging/bootupd.spec
+++ b/contrib/packaging/bootupd.spec
@@ -11,7 +11,9 @@ License:        Apache-2.0
 URL:            https://github.com/coreos/bootupd
 Source0:        %{url}/releases/download/v%{version}/bootupd-%{version}.tar.zstd
 Source1:        %{url}/releases/download/v%{version}/bootupd-%{version}-vendor.tar.zstd
+%if 0%{?fedora} || 0%{?rhel} >= 10
 ExcludeArch:    %{ix86}
+%endif
 
 BuildRequires: git
 # For now, see upstream


### PR DESCRIPTION
pairs with: https://gitlab.com/redhat/centos-stream/rpms/rust-bootupd/-/merge_requests/24