### PR TITLE
xtask: create target dir before make srpm

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -76,6 +76,7 @@ fn gitrev(sh: &Shell) -> Result<String> {
 
 /// Return a string formatted version of the git commit timestamp, up to the minute
 /// but not second because, well, we're not going to build more than once a second.
+#[allow(dead_code)]
 #[context("Finding git timestamp")]
 fn git_timestamp(sh: &Shell) -> Result<String> {
     let ts = cmd!(sh, "git show -s --format=%ct").read()?;
@@ -236,6 +237,7 @@ fn impl_srpm(sh: &Shell) -> Result<Utf8PathBuf> {
 }
 
 fn package_srpm(sh: &Shell) -> Result<()> {
+    let _targetdir = get_target_dir()?;
     let srpm = impl_srpm(sh)?;
     println!("Generated: {srpm}");
     Ok(())


### PR DESCRIPTION
Fix:
```
$ git archive --format=tar --prefix=bootupd-0.2.27.49.g78dc8d3/ -o target/bootupd-0.2.27.49.g78dc8d3.tar HEAD
fatal: could not open 'target/bootupd-0.2.27.49.g78dc8d3.tar' for writing: No such file or directory
error: Packaging: command exited with non-zero code `git archive --format=tar --prefix=bootupd-0.2.27.49.g78dc8d3/ -o target/bootupd-0.2.27.49.g78dc8d3.tar HEAD`: 128
make: *** [/mnt/workdir-x9znfd3k/bootupd/.copr/Makefile:6: srpm] Error 1
```