### PR TITLE
Cargo.toml: bump MSRV to 1.84.1

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -35,5 +35,9 @@ jobs:
           run: |
             set -xeu
             apt update -y
-            apt install -y gcc make cargo libssl-dev pkg-config
+            apt install -y gcc make curl libssl-dev pkg-config
+            # Install Rust 1.84.1
+            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.84.1
+            source $HOME/.cargo/env
+            rustc --version
             cargo check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 version = "0.2.27"
 authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2021"
-rust-version = "1.75.0"
+rust-version = "1.84.1"
 homepage = "https://github.com/coreos/bootupd"
 
 include = ["src", "LICENSE", "Makefile", "systemd"]


### PR DESCRIPTION
Simlar to https://github.com/coreos/coreos-installer/commit/948e9367b5401516fddfe73056662091b7471b00

update rust lint_toolchain to 1.84.1 in https://github.com/coreos/bootupd/pull/894