### PR TITLE
support riscv64

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ that's for tools like `grubby` and `ostree`.
 ## Status
 
 bootupd supports updating GRUB and shim for UEFI firmware on
-x86_64 and aarch64, and GRUB for BIOS firmware on x86_64.
+x86_64, aarch64, and riscv64, and GRUB for BIOS firmware on x86_64
+and ppc64le.
 The project is [deployed in Fedora CoreOS](https://docs.fedoraproject.org/en-US/fedora-coreos/bootloader-updates/) and derivatives,
 and is also used by the new [`bootc install`](https://github.com/containers/bootc/#using-bootc-install)
 functionality.  The bootupd CLI should be considered stable.

--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -3,7 +3,11 @@ use crate::bios;
 use crate::component;
 use crate::component::{Component, ValidationResult};
 use crate::coreos;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "riscv64"
+))]
 use crate::efi;
 use crate::model::{ComponentStatus, ComponentUpdatable, ContentMetadata, SavedState, Status};
 use crate::util;
@@ -113,7 +117,8 @@ pub(crate) fn install(
             #[cfg(any(
                 target_arch = "x86_64",
                 target_arch = "aarch64",
-                target_arch = "powerpc64"
+                target_arch = "powerpc64",
+                target_arch = "riscv64"
             ))]
             crate::grubconfigs::install(sysroot, installed_efi_vendor.as_deref(), uuid)?;
             // On other architectures, assume that there's nothing to do.
@@ -163,7 +168,7 @@ pub(crate) fn get_components_impl(auto: bool) -> Components {
             insert_component(&mut components, Box::new(efi::Efi::default()));
         }
     }
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     insert_component(&mut components, Box::new(efi::Efi::default()));
 
     #[cfg(target_arch = "powerpc64")]
@@ -390,7 +395,11 @@ pub(crate) fn print_status(status: &Status) -> Result<()> {
         println!("CoreOS aleph version: {}", coreos_aleph.aleph.version);
     }
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64"
+    ))]
     {
         let boot_method = if efi::is_efi_booted()? { "EFI" } else { "BIOS" };
         println!("Boot method: {}", boot_method);

--- a/src/component.rs
+++ b/src/component.rs
@@ -80,7 +80,11 @@ pub(crate) trait Component {
 /// Given a component name, create an implementation.
 pub(crate) fn new_from_name(name: &str) -> Result<Box<dyn Component>> {
     let r: Box<dyn Component> = match name {
-        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+        #[cfg(any(
+            target_arch = "x86_64",
+            target_arch = "aarch64",
+            target_arch = "riscv64"
+        ))]
         #[allow(clippy::box_default)]
         "EFI" => Box::new(crate::efi::Efi::default()),
         #[cfg(any(target_arch = "x86_64", target_arch = "powerpc64"))]
@@ -93,14 +97,22 @@ pub(crate) fn new_from_name(name: &str) -> Result<Box<dyn Component>> {
 
 /// Returns the path to the payload directory for an available update for
 /// a component.
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "riscv64"
+))]
 pub(crate) fn component_updatedirname(component: &dyn Component) -> PathBuf {
     Path::new(BOOTUPD_UPDATES_DIR).join(component.name())
 }
 
 /// Returns the path to the payload directory for an available update for
 /// a component.
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "riscv64"
+))]
 pub(crate) fn component_updatedir(sysroot: &str, component: &dyn Component) -> PathBuf {
     Path::new(sysroot).join(component_updatedirname(component))
 }

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -36,6 +36,9 @@ pub(crate) const SHIM: &str = "shimaa64.efi";
 #[cfg(target_arch = "x86_64")]
 pub(crate) const SHIM: &str = "shimx64.efi";
 
+#[cfg(target_arch = "riscv64")]
+pub(crate) const SHIM: &str = "shimriscv64.efi";
+
 /// The ESP partition label on Fedora CoreOS derivatives
 pub(crate) const COREOS_ESP_PART_LABEL: &str = "EFI-SYSTEM";
 pub(crate) const ANACONDA_ESP_PART_LABEL: &str = "EFI\\x20System\\x20Partition";

--- a/src/filetree.rs
+++ b/src/filetree.rs
@@ -4,33 +4,61 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "riscv64"
+))]
 use anyhow::{bail, Context, Result};
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "riscv64"
+))]
 use camino::{Utf8Path, Utf8PathBuf};
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "riscv64"
+))]
 use openat_ext::OpenatDirExt;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "riscv64"
+))]
 use openssl::hash::{Hasher, MessageDigest};
 use rustix::fd::BorrowedFd;
 use serde::{Deserialize, Serialize};
 #[allow(unused_imports)]
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Display;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "riscv64"
+))]
 use std::os::unix::io::AsRawFd;
 use std::os::unix::process::CommandExt;
 use std::process::Command;
 
 /// The prefix we apply to our temporary files.
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "riscv64"
+))]
 pub(crate) const TMP_PREFIX: &str = ".btmp.";
 // This module doesn't handle modes right now, because
 // we're only targeting FAT filesystems for UEFI.
 // In FAT there are no unix permission bits, usually
 // they're set by mount options.
 // See also https://github.com/coreos/fedora-coreos-config/commit/8863c2b34095a2ae5eae6fbbd121768a5f592091
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "riscv64"
+))]
 const DEFAULT_FILE_MODE: u32 = 0o700;
 
 use crate::sha512string::SHA512String;
@@ -79,7 +107,11 @@ impl FileTreeDiff {
 }
 
 impl FileMetadata {
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64"
+    ))]
     pub(crate) fn new_from_path<P: openat::AsPath>(
         dir: &openat::Dir,
         name: P,
@@ -99,7 +131,11 @@ impl FileMetadata {
 
 impl FileTree {
     // Internal helper to generate a sub-tree
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64"
+    ))]
     fn unsorted_from_dir(dir: &openat::Dir) -> Result<HashMap<String, FileMetadata>> {
         let mut ret = HashMap::new();
         for entry in dir.list_dir(".")? {
@@ -136,7 +172,11 @@ impl FileTree {
     }
 
     /// Create a FileTree from the target directory.
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64"
+    ))]
     pub(crate) fn new_from_dir(dir: &openat::Dir) -> Result<Self> {
         let mut children = BTreeMap::new();
         for (k, v) in Self::unsorted_from_dir(dir)?.drain() {
@@ -147,7 +187,11 @@ impl FileTree {
     }
 
     /// Determine the changes *from* self to the updated tree
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64"
+    ))]
     pub(crate) fn diff(&self, updated: &Self) -> Result<FileTreeDiff> {
         self.diff_impl(updated, true)
     }
@@ -167,7 +211,11 @@ impl FileTree {
         current.diff_impl(self, false)
     }
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64"
+    ))]
     fn diff_impl(&self, updated: &Self, check_additions: bool) -> Result<FileTreeDiff> {
         let mut additions = HashSet::new();
         let mut removals = HashSet::new();
@@ -199,7 +247,11 @@ impl FileTree {
 
     /// Create a diff from a target directory.  This will ignore
     /// any files or directories that are not part of the original tree.
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64"
+    ))]
     pub(crate) fn relative_diff_to(&self, dir: &openat::Dir) -> Result<FileTreeDiff> {
         let mut removals = HashSet::new();
         let mut changes = HashSet::new();
@@ -233,7 +285,11 @@ impl FileTree {
 }
 
 // Recursively remove all files/dirs in the directory that start with our TMP_PREFIX
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "riscv64"
+))]
 fn cleanup_tmp(dir: &openat::Dir) -> Result<()> {
     for entry in dir.list_dir(".")? {
         let entry = entry?;
@@ -264,7 +320,11 @@ fn cleanup_tmp(dir: &openat::Dir) -> Result<()> {
 }
 
 #[derive(Default, Clone)]
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "riscv64"
+))]
 pub(crate) struct ApplyUpdateOptions {
     pub(crate) skip_removals: bool,
     pub(crate) skip_sync: bool,
@@ -274,7 +334,11 @@ pub(crate) struct ApplyUpdateOptions {
 // to be bound in nix today.  I found https://github.com/XuShaohua/nc
 // but that's a nontrivial dependency with not a lot of code review.
 // Let's just fork off a helper process for now.
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "riscv64"
+))]
 pub(crate) fn syncfs(d: &openat::Dir) -> Result<()> {
     use rustix::fs::{Mode, OFlags};
     let d = unsafe { BorrowedFd::borrow_raw(d.as_raw_fd()) };
@@ -284,7 +348,11 @@ pub(crate) fn syncfs(d: &openat::Dir) -> Result<()> {
 }
 
 /// Copy from src to dst at root dir
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "riscv64"
+))]
 fn copy_dir(root: &openat::Dir, src: &str, dst: &str) -> Result<()> {
     use bootc_utils::CommandRunExt;
 
@@ -304,7 +372,11 @@ fn copy_dir(root: &openat::Dir, src: &str, dst: &str) -> Result<()> {
 /// Get first sub dir and tmp sub dir for the path
 /// "fedora/foo/bar" -> ("fedora", ".btmp.fedora")
 /// "foo" -> ("foo", ".btmp.foo")
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "riscv64"
+))]
 fn get_first_dir(path: &Utf8Path) -> Result<(&Utf8Path, String)> {
     let first = path
         .iter()
@@ -316,7 +388,11 @@ fn get_first_dir(path: &Utf8Path) -> Result<(&Utf8Path, String)> {
 }
 
 /// Given two directories, apply a diff generated from srcdir to destdir
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "riscv64"
+))]
 pub(crate) fn apply_diff(
     srcdir: &openat::Dir,
     destdir: &openat::Dir,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 **Boot**loader **upd**ater.
 
 This is an early prototype hidden/not-yet-standardized mechanism
-which just updates EFI for now (x86_64/aarch64 only).
+which just updates EFI for now (x86_64/aarch64/riscv64 only).
 
 But in the future will hopefully gain some independence from
 ostree and also support e.g. updating the MBR etc.
@@ -24,7 +24,11 @@ mod bootupd;
 mod cli;
 mod component;
 mod coreos;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "riscv64"
+))]
 mod efi;
 mod failpoints;
 mod filesystem;
@@ -32,7 +36,8 @@ mod filetree;
 #[cfg(any(
     target_arch = "x86_64",
     target_arch = "aarch64",
-    target_arch = "powerpc64"
+    target_arch = "powerpc64",
+    target_arch = "riscv64"
 ))]
 mod grubconfigs;
 mod model;

--- a/src/ostreeutil.rs
+++ b/src/ostreeutil.rs
@@ -10,7 +10,11 @@ use anyhow::Result;
 use log::debug;
 
 /// https://github.com/coreos/rpm-ostree/pull/969/commits/dc0e8db5bd92e1f478a0763d1a02b48e57022b59
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "riscv64"
+))]
 pub(crate) const BOOT_PREFIX: &str = "usr/lib/ostree-boot";
 const LEGACY_RPMOSTREE_DBPATH: &str = "usr/share/rpm";
 const SYSIMAGE_RPM_DBPATH: &str = "usr/lib/sysimage/rpm";


### PR DESCRIPTION
Allows update EFI bootloader on riscv64 similar to aarch64 and x86_64.

xref: https://github.com/coreos/fedora-coreos-tracker/issues/1931