### PR TITLE
efi: add `context` when openning directory

### DIFF
--- a/src/efi.rs
+++ b/src/efi.rs
@@ -379,7 +379,8 @@ impl Component for Efi {
             Command::new("mv").args([&efisrc, &dest_efidir]).run()?;
         }
 
-        let efidir = openat::Dir::open(&dest_efidir)?;
+        let efidir = openat::Dir::open(&dest_efidir)
+            .with_context(|| format!("Opening {}", dest_efidir.display()))?;
         let files = crate::util::filenames(&efidir)?.into_iter().map(|mut f| {
             f.insert_str(0, "/boot/efi/EFI/");
             f


### PR DESCRIPTION
This is not to fix the issue, add context to print more info for
https://github.com/coreos/bootupd/issues/915
For example:
`error: generating metadata failed: Opening /usr/lib/bootupd/
updates/EFI: No such file or directory (os error 2)`