### PR TITLE
efi: rewrite `ensure_mounted_esp()`

### DIFF
--- a/src/bios.rs
+++ b/src/bios.rs
@@ -159,15 +159,15 @@ impl Component for Bios {
 
     fn adopt_update(
         &self,
-        sysroot: &RootContext,
+        rootcxt: &RootContext,
         update: &ContentMetadata,
     ) -> Result<InstalledContent> {
-        let bios_devices = blockdev::find_colocated_bios_boot(&sysroot.devices)?;
+        let bios_devices = blockdev::find_colocated_bios_boot(&rootcxt.devices)?;
         let Some(meta) = self.query_adopt(&bios_devices)? else {
             anyhow::bail!("Failed to find adoptable system")
         };
 
-        let mut parent_devices = sysroot.devices.iter();
+        let mut parent_devices = rootcxt.devices.iter();
         let Some(parent) = parent_devices.next() else {
             anyhow::bail!("Failed to find parent device");
         };
@@ -177,8 +177,8 @@ impl Component for Bios {
                 "Found multiple parent devices {parent} and {next}; not currently supported"
             );
         }
-        self.run_grub_install(sysroot.path.as_str(), &parent)?;
-        log::debug!("Install grub modules on {parent}");
+        self.run_grub_install(rootcxt.path.as_str(), &parent)?;
+        log::debug!("Installed grub modules on {parent}");
         Ok(InstalledContent {
             meta: update.clone(),
             filetree: None,
@@ -190,12 +190,12 @@ impl Component for Bios {
         get_component_update(sysroot, self)
     }
 
-    fn run_update(&self, sysroot: &RootContext, _: &InstalledContent) -> Result<InstalledContent> {
+    fn run_update(&self, rootcxt: &RootContext, _: &InstalledContent) -> Result<InstalledContent> {
         let updatemeta = self
-            .query_update(&sysroot.sysroot)?
+            .query_update(&rootcxt.sysroot)?
             .expect("update available");
 
-        let mut parent_devices = sysroot.devices.iter();
+        let mut parent_devices = rootcxt.devices.iter();
         let Some(parent) = parent_devices.next() else {
             anyhow::bail!("Failed to find parent device");
         };
@@ -206,7 +206,7 @@ impl Component for Bios {
             );
         }
 
-        self.run_grub_install(sysroot.path.as_str(), &parent)?;
+        self.run_grub_install(rootcxt.path.as_str(), &parent)?;
         log::debug!("Install grub modules on {parent}");
 
         let adopted_from = None;

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -63,7 +63,7 @@ pub fn find_colocated_esps(devices: &Vec<String>) -> Result<Option<Vec<String>>>
     if esps.is_empty() {
         return Ok(None);
     }
-    log::debug!("Find esp partitions: {esps:?}");
+    log::debug!("Found esp partitions: {esps:?}");
     Ok(Some(esps))
 }
 
@@ -93,6 +93,6 @@ pub fn find_colocated_bios_boot(devices: &Vec<String>) -> Result<Option<Vec<Stri
     if bios_boots.is_empty() {
         return Ok(None);
     }
-    log::debug!("Find bios_boot partitions: {bios_boots:?}");
+    log::debug!("Found bios_boot partitions: {bios_boots:?}");
     Ok(Some(bios_boots))
 }

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -23,6 +23,7 @@ pub fn get_devices<P: AsRef<Path>>(target_root: P) -> Result<Vec<String>> {
 }
 
 // Get single device for the target root
+#[allow(dead_code)]
 pub fn get_single_device<P: AsRef<Path>>(target_root: P) -> Result<String> {
     let mut devices = get_devices(&target_root)?.into_iter();
     let Some(parent) = devices.next() else {
@@ -37,7 +38,6 @@ pub fn get_single_device<P: AsRef<Path>>(target_root: P) -> Result<String> {
 
 /// Find esp partition on the same device
 /// using sfdisk to get partitiontable
-#[allow(dead_code)]
 pub fn get_esp_partition(device: &str) -> Result<Option<String>> {
     const ESP_TYPE_GUID: &str = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B";
     let device_info: PartitionTable = bootc_blockdev::partitions_of(Utf8Path::new(device))?;
@@ -51,21 +51,20 @@ pub fn get_esp_partition(device: &str) -> Result<Option<String>> {
     Ok(None)
 }
 
-/// Find all ESP partitions on the devices with mountpoint boot
-#[allow(dead_code)]
-pub fn find_colocated_esps<P: AsRef<Path>>(target_root: P) -> Result<Vec<String>> {
-    // first, get the parent device
-    let devices = get_devices(&target_root).with_context(|| "while looking for colocated ESPs")?;
-
-    // now, look for all ESPs on those devices
+/// Find all ESP partitions on the devices
+pub fn find_colocated_esps(devices: &Vec<String>) -> Result<Option<Vec<String>>> {
+    // look for all ESPs on those devices
     let mut esps = Vec::new();
     for device in devices {
         if let Some(esp) = get_esp_partition(&device)? {
             esps.push(esp)
         }
     }
+    if esps.is_empty() {
+        return Ok(None);
+    }
     log::debug!("Find esp partitions: {esps:?}");
-    Ok(esps)
+    Ok(Some(esps))
 }
 
 /// Find bios_boot partition on the same device
@@ -82,20 +81,18 @@ pub fn get_bios_boot_partition(device: &str) -> Result<Option<String>> {
     Ok(None)
 }
 
-/// Find all bios_boot partitions on the devices with mountpoint boot
-#[allow(dead_code)]
-pub fn find_colocated_bios_boot<P: AsRef<Path>>(target_root: P) -> Result<Vec<String>> {
-    // first, get the parent device
-    let devices =
-        get_devices(&target_root).with_context(|| "looking for colocated bios_boot parts")?;
-
-    // now, look for all bios_boot parts on those devices
+/// Find all bios_boot partitions on the devices
+pub fn find_colocated_bios_boot(devices: &Vec<String>) -> Result<Option<Vec<String>>> {
+    // look for all bios_boot parts on those devices
     let mut bios_boots = Vec::new();
     for device in devices {
         if let Some(bios) = get_bios_boot_partition(&device)? {
             bios_boots.push(bios)
         }
     }
+    if bios_boots.is_empty() {
+        return Ok(None);
+    }
     log::debug!("Find bios_boot partitions: {bios_boots:?}");
-    Ok(bios_boots)
+    Ok(Some(bios_boots))
 }

--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -276,7 +276,7 @@ pub(crate) fn adopt_and_update(name: &str, rootcxt: &RootContext) -> Result<Cont
         SavedState::acquire_write_lock(sysroot).context("Failed to acquire write lock")?;
 
     let inst = component
-        .adopt_update(&state_guard.sysroot, &update)
+        .adopt_update(&rootcxt, &update)
         .context("Failed adopt and update")?;
     state.installed.insert(component.name().into(), inst);
 
@@ -327,8 +327,10 @@ pub(crate) fn status() -> Result<Status> {
 
     // Process the remaining components not installed
     log::trace!("Remaining known components: {}", known_components.len());
-    for (name, component) in known_components {
-        if let Some(adopt_ver) = component.query_adopt()? {
+    for (name, _) in known_components {
+        // Only run `query_adopt_state()` is enough
+        // When do adopt and update for each component, will check more
+        if let Some(adopt_ver) = crate::component::query_adopt_state()? {
             ret.adoptable.insert(name.to_string(), adopt_ver);
         } else {
             log::trace!("Not adoptable: {}", name);

--- a/src/component.rs
+++ b/src/component.rs
@@ -34,7 +34,7 @@ pub(crate) trait Component {
     /// Given an adoptable system and an update, perform the update.
     fn adopt_update(
         &self,
-        sysroot: &RootContext,
+        rootcxt: &RootContext,
         update: &ContentMetadata,
     ) -> Result<InstalledContent>;
 
@@ -66,7 +66,7 @@ pub(crate) trait Component {
     /// Used on the client to run an update.
     fn run_update(
         &self,
-        sysroot: &RootContext,
+        rootcxt: &RootContext,
         current: &InstalledContent,
     ) -> Result<InstalledContent>;
 

--- a/src/component.rs
+++ b/src/component.rs
@@ -29,12 +29,12 @@ pub(crate) trait Component {
     /// In an operating system whose initially booted disk image is not
     /// using bootupd, detect whether it looks like the component exists
     /// and "synthesize" content metadata from it.
-    fn query_adopt(&self) -> Result<Option<Adoptable>>;
+    fn query_adopt(&self, devices: &Option<Vec<String>>) -> Result<Option<Adoptable>>;
 
     /// Given an adoptable system and an update, perform the update.
     fn adopt_update(
         &self,
-        sysroot: &openat::Dir,
+        sysroot: &RootContext,
         update: &ContentMetadata,
     ) -> Result<InstalledContent>;
 


### PR DESCRIPTION
This is the preparation for https://github.com/coreos/bootupd/pull/855.

The main target for this PR is: "efi: rewrite `ensure_mounted_esp()`", but find there are much to update consequently.

---
efi: rewrite `ensure_mounted_esp()`

Split into 2 parts:
- `get_mounted_esp()` to get mounted point esp
- `mount_esp_device()` to mount the passed esp device, return
the mount point

Then in `ensure_mounted_esp()` call the above 2 functions:
firstly check if esp is already mounted, if not, mount the passed
esp device.

---
efi: update `install()` and `update()` according to split change

---
adopt_update: pass `RootContext` as parameter

---
efi: update `validate()` according to the split change