### PR TITLE
adopt: fix adoption when booting with BIOS firmware without ESP

### DIFF
--- a/src/bios.rs
+++ b/src/bios.rs
@@ -161,10 +161,10 @@ impl Component for Bios {
         &self,
         rootcxt: &RootContext,
         update: &ContentMetadata,
-    ) -> Result<InstalledContent> {
+    ) -> Result<Option<InstalledContent>> {
         let bios_devices = blockdev::find_colocated_bios_boot(&rootcxt.devices)?;
         let Some(meta) = self.query_adopt(&bios_devices)? else {
-            anyhow::bail!("Failed to find adoptable system")
+            return Ok(None);
         };
 
         let mut parent_devices = rootcxt.devices.iter();
@@ -179,11 +179,11 @@ impl Component for Bios {
         }
         self.run_grub_install(rootcxt.path.as_str(), &parent)?;
         log::debug!("Installed grub modules on {parent}");
-        Ok(InstalledContent {
+        Ok(Some(InstalledContent {
             meta: update.clone(),
             filetree: None,
             adopted_from: Some(meta.version),
-        })
+        }))
     }
 
     fn query_update(&self, sysroot: &openat::Dir) -> Result<Option<ContentMetadata>> {

--- a/src/component.rs
+++ b/src/component.rs
@@ -36,7 +36,7 @@ pub(crate) trait Component {
         &self,
         rootcxt: &RootContext,
         update: &ContentMetadata,
-    ) -> Result<InstalledContent>;
+    ) -> Result<Option<InstalledContent>>;
 
     /// Implementation of `bootupd install` for a given component.  This should
     /// gather data (or run binaries) from the source root, and install them


### PR DESCRIPTION
We should support adoption when :
- booting with BIOS firmware without ESP
- booting with UEFI firmware without BIOS BOOT part

Fix regression issue https://github.com/coreos/bootupd/issues/943, which is introduced by https://github.com/coreos/bootupd/commit/fe53bab2d325c18e15faa871bdc44e228b742840