### PR TITLE
Add fsfreeze_thaw_cycle() + small cleanups

### DIFF
--- a/src/freezethaw.rs
+++ b/src/freezethaw.rs
@@ -1,0 +1,50 @@
+use rustix::fd::AsFd;
+use rustix::ffi as c;
+use rustix::io::Errno;
+use rustix::ioctl::opcode;
+use rustix::{io, ioctl};
+
+use crate::util::SignalTerminationGuard;
+
+fn ioctl_fifreeze<Fd: AsFd>(fd: Fd) -> io::Result<()> {
+    // SAFETY: `FIFREEZE` is a no-argument opcode.
+    // `FIFREEZE` is defined as `_IOWR('X', 119, int)`.
+    unsafe {
+        let ctl = ioctl::NoArg::<{ opcode::read_write::<c::c_int>(b'X', 119) }>::new();
+        ioctl::ioctl(fd, ctl)
+    }
+}
+
+fn ioctl_fithaw<Fd: AsFd>(fd: Fd) -> io::Result<()> {
+    // SAFETY: `FITHAW` is a no-argument opcode.
+    // `FITHAW` is defined as `_IOWR('X', 120, int)`.
+    unsafe {
+        let ctl = ioctl::NoArg::<{ opcode::read_write::<c::c_int>(b'X', 120) }>::new();
+        ioctl::ioctl(fd, ctl)
+    }
+}
+
+/// syncfs() doesn't flush the journal on XFS,
+/// and since GRUB2 can't read the XFS journal, the system
+/// could fail to boot.
+///
+/// http://marc.info/?l=linux-fsdevel&m=149520244919284&w=2
+/// https://github.com/ostreedev/ostree/pull/1049
+///
+/// This function always call syncfs() first, then calls
+/// `ioctl(FIFREEZE)` and `ioctl(FITHAW)`, ignoring `EOPNOTSUPP` and `EPERM`
+pub(crate) fn fsfreeze_thaw_cycle<Fd: AsFd>(fd: Fd) -> anyhow::Result<()> {
+    rustix::fs::syncfs(&fd)?;
+
+    let _guard = SignalTerminationGuard::new()?;
+
+    let freeze = ioctl_fifreeze(&fd);
+    match freeze {
+        // Ignore permissions errors (tests)
+        Err(Errno::PERM) => Ok(()),
+        // Ignore unsupported FS
+        Err(Errno::NOTSUP) => Ok(()),
+        Ok(()) => Ok(ioctl_fithaw(fd)?),
+        _ => Ok(freeze?),
+    }
+}

--- a/src/grubconfigs.rs
+++ b/src/grubconfigs.rs
@@ -60,8 +60,9 @@ pub(crate) fn install(
         println!("Added {name}");
     }
 
-    bootdir
-        .write_file_contents(format!("{GRUB2DIR}/grub.cfg"), 0o644, config.as_bytes())
+    let grub2dir = bootdir.sub_dir(GRUB2DIR)?;
+    grub2dir
+        .write_file_contents("grub.cfg", 0o644, config.as_bytes())
         .context("Copying grub-static.cfg")?;
     println!("Installed: grub.cfg");
 
@@ -74,10 +75,11 @@ pub(crate) fn install(
             .uuid
             .ok_or_else(|| anyhow::anyhow!("Failed to find UUID for boot"))?;
         let grub2_uuid_contents = format!("set BOOT_UUID=\"{bootfs_uuid}\"\n");
-        let uuid_path = format!("{GRUB2DIR}/bootuuid.cfg");
-        bootdir
-            .write_file_contents(&uuid_path, 0o644, grub2_uuid_contents)
+        let uuid_path = "bootuuid.cfg";
+        grub2dir
+            .write_file_contents(uuid_path, 0o644, grub2_uuid_contents)
             .context("Writing bootuuid.cfg")?;
+        println!("Installed: bootuuid.cfg");
         Some(uuid_path)
     } else {
         None
@@ -96,12 +98,11 @@ pub(crate) fn install(
                 .context("Copying static EFI")?;
             println!("Installed: {target:?}");
             if let Some(uuid_path) = uuid_path {
-                // SAFETY: we always have a filename
-                let filename = Path::new(&uuid_path).file_name().unwrap();
-                let target = &vendor.join(filename);
-                bootdir
+                let target = &vendor.join(uuid_path);
+                grub2dir
                     .copy_file_at(uuid_path, &efidir, target)
                     .context("Writing bootuuid.cfg to efi dir")?;
+                println!("Installed: {target:?}");
             }
         }
     }

--- a/src/grubconfigs.rs
+++ b/src/grubconfigs.rs
@@ -7,6 +7,8 @@ use bootc_utils::CommandRunExt;
 use fn_error_context::context;
 use openat_ext::OpenatDirExt;
 
+use crate::freezethaw::fsfreeze_thaw_cycle;
+
 /// The subdirectory of /boot we use
 const GRUB2DIR: &str = "grub2";
 const CONFIGDIR: &str = "/usr/lib/bootupd/grub2-static";
@@ -85,6 +87,8 @@ pub(crate) fn install(
         None
     };
 
+    fsfreeze_thaw_cycle(grub2dir.open_file(".")?)?;
+
     if let Some(vendordir) = installed_efi_vendor {
         log::debug!("vendordir={:?}", &vendordir);
         let vendor = PathBuf::from(vendordir);
@@ -104,6 +108,7 @@ pub(crate) fn install(
                     .context("Writing bootuuid.cfg to efi dir")?;
                 println!("Installed: {target:?}");
             }
+            fsfreeze_thaw_cycle(efidir.open_file(".")?)?;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ mod efi;
 mod failpoints;
 mod filesystem;
 mod filetree;
+mod freezethaw;
 #[cfg(any(
     target_arch = "x86_64",
     target_arch = "aarch64",


### PR DESCRIPTION
I went with a simple implementation of `fsfreeze_thaw_cycle()` compared to the ostree one as we are already protected from SIGTERM, and in case FIFREEZE is slow / stuck, there is no indication calling FITHAW will help, so l prefer to keep it simple.
I can move [grubconfigs: cleanup install()](https://github.com/coreos/bootupd/commit/432d56e48bfc3c380d88804a6127007a45e90e0f) to another PR but it need to be merged first