### PR TITLE
Release 0.2.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "bootupd"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bootupd"
 description = "Bootloader updater"
 license = "Apache-2.0"
-version = "0.2.27"
+version = "0.2.28"
 authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2021"
 rust-version = "1.84.1"


### PR DESCRIPTION
This release introduces five notable changes:
- Allows update EFI bootloader on `riscv64` similar to `aarch64` and `x86_64`. (https://github.com/coreos/bootupd/pull/916)
- Rework `grub2` default static config (https://github.com/coreos/bootupd/pull/841), that includes:
    - Add support for `GRUB2_PASSWORD` in user.cfg (partially fix https://issues.redhat.com/browse/RHEL-78299)
    - Include dropins instead of sourcing them, this should help updating config in the future
    - Add multiple small dropins to match classic grub2 installs
- Add a simple implementation of `fsfreeze_thaw_cycle()`, that always call `syncfs()` first, then calls `ioctl(FIFREEZE)` and `ioctl(FITHAW)`. This function ensures filesystem state is fully flushed — especially for XFS. (https://github.com/coreos/bootupd/pull/948)
- Support updating multiple EFIs in mirrored setups (RAID1). (https://github.com/coreos/bootupd/pull/855)
- Add adopt tag to install the static GRUB config from tree. (https://github.com/coreos/bootupd/pull/945)