### PR TITLE
grubconfig: set `/boot/grub2/grub.cfg` file mode to `0600`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,12 @@ jobs:
           fi
           sudo ls /mnt/EFI/centos/{grub.cfg,${shim}}
           sudo umount /mnt
+          # check /boot/grub2/grub.cfg permission
+          root_part=$(sudo sfdisk -l -J "${device}" | jq -r '.partitiontable.partitions[] | select(.name == "root").node')
+          sudo mount "${root_part}" /mnt/
+          sudo ls /mnt/boot/grub2/grub.cfg
+          [ $(sudo stat -c "%a" /mnt/boot/grub2/grub.cfg) == "600" ]
+          sudo umount /mnt
           sudo losetup -D "${device}"
           sudo rm -f myimage.raw
 
@@ -99,3 +105,4 @@ jobs:
             --disable-selinux --replace=alongside /target
           # Verify we injected static configs
           jq -re '.["static-configs"].version' /boot/bootupd-state.json
+          [ $(sudo stat -c "%a" /boot/grub2/grub.cfg) == "600" ]

--- a/src/grubconfigs.rs
+++ b/src/grubconfigs.rs
@@ -17,6 +17,9 @@ const DROPINDIR: &str = "configs.d";
 const GRUBENV: &str = "grubenv";
 pub(crate) const GRUBCONFIG: &str = "grub.cfg";
 pub(crate) const GRUBCONFIG_BACKUP: &str = "grub.cfg.backup";
+// File mode for /boot/grub2/grub.config
+// https://github.com/coreos/bootupd/issues/952
+const GRUBCONFIG_FILE_MODE: u32 = 0o600;
 
 /// Install the static GRUB config files.
 #[context("Installing static GRUB configs")]
@@ -67,7 +70,7 @@ pub(crate) fn install(
 
     let grub2dir = bootdir.sub_dir(GRUB2DIR)?;
     grub2dir
-        .write_file_contents("grub.cfg", 0o644, config.as_bytes())
+        .write_file_contents("grub.cfg", GRUBCONFIG_FILE_MODE, config.as_bytes())
         .context("Copying grub-static.cfg")?;
     println!("Installed: grub.cfg");
 


### PR DESCRIPTION
Copy Colin's comment:
```
One overall issue on this is because we don't have a mechanism to
update the static configs, existing systems will stay as is.
```

See https://github.com/coreos/bootupd/issues/952 &
https://redhat-internal.slack.com/archives/C01BSEK9PM1/p1750152540290679