### PR TITLE
Use published bootc-internal-{utils,blockdev} crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,12 +155,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "bootc-blockdev"
+name = "bootc-internal-blockdev"
 version = "0.0.0"
-source = "git+https://github.com/containers/bootc?rev=v1.3.0#b06d75fed73f26a974423a9db41e19413987fca3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12bb9c7f9e3f9ce605ae80d95f53a4957cacd95d8f022d9f7745bcdf1b9a94c4"
 dependencies = [
  "anyhow",
- "bootc-utils",
+ "bootc-internal-utils",
  "camino",
  "fn-error-context",
  "regex",
@@ -170,9 +171,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bootc-utils"
+name = "bootc-internal-utils"
 version = "0.0.0"
-source = "git+https://github.com/containers/bootc?rev=v1.3.0#b06d75fed73f26a974423a9db41e19413987fca3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7576a42b06b4d1d4005aac27f93b848bda3d80b6c80a6f1aa0f494b957351b81"
 dependencies = [
  "anyhow",
  "chrono",
@@ -192,8 +194,8 @@ version = "0.2.28"
 dependencies = [
  "anyhow",
  "bincode",
- "bootc-blockdev",
- "bootc-utils",
+ "bootc-internal-blockdev",
+ "bootc-internal-utils",
  "camino",
  "cap-std-ext",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3.2"
-bootc-blockdev = { git = "https://github.com/containers/bootc", rev = "v1.3.0" }
-bootc-utils = { git = "https://github.com/containers/bootc", rev = "v1.3.0" }
+bootc-internal-blockdev = "0.0.0"
+bootc-internal-utils = "0.0.0"
 cap-std-ext = "4.0.6"
 camino = "1.1.9"
 chrono = { version = "0.4.41", features = ["serde"] }

--- a/src/bios.rs
+++ b/src/bios.rs
@@ -24,13 +24,13 @@ fn target_device(device: &str) -> Result<Cow<str>> {
     const PREPBOOT_MBR_TYPE: &str = "41";
 
     // Here we use lsblk to see if the device has any partitions at all
-    let dev = bootc_blockdev::list_dev(device.into())?;
+    let dev = bootc_internal_blockdev::list_dev(device.into())?;
     if dev.children.is_none() {
         return Ok(device.into());
     };
     // If it does, directly call `sfdisk` and bypass lsblk because inside a container
     // we may not have all the cached udev state (that I think is in /run).
-    let device = bootc_blockdev::partitions_of(device.into())?;
+    let device = bootc_internal_blockdev::partitions_of(device.into())?;
     let prepdev = device
         .partitions
         .iter()

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -2,7 +2,7 @@ use camino::Utf8Path;
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use bootc_blockdev::PartitionTable;
+use bootc_internal_blockdev::PartitionTable;
 use fn_error_context::context;
 
 #[context("get parent devices from mount point boot or sysroot")]
@@ -30,7 +30,7 @@ pub fn get_devices<P: AsRef<Path>>(target_root: P) -> Result<Vec<String>> {
     };
 
     // Find the parent devices of the source path
-    let parent_devices = bootc_blockdev::find_parent_devices(&source)
+    let parent_devices = bootc_internal_blockdev::find_parent_devices(&source)
         .with_context(|| format!("While looking for backing devices of {}", source))?;
     log::debug!("Found parent devices: {parent_devices:?}");
     Ok(parent_devices)
@@ -40,7 +40,8 @@ pub fn get_devices<P: AsRef<Path>>(target_root: P) -> Result<Vec<String>> {
 /// using sfdisk to get partitiontable
 pub fn get_esp_partition(device: &str) -> Result<Option<String>> {
     const ESP_TYPE_GUID: &str = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B";
-    let device_info: PartitionTable = bootc_blockdev::partitions_of(Utf8Path::new(device))?;
+    let device_info: PartitionTable =
+        bootc_internal_blockdev::partitions_of(Utf8Path::new(device))?;
     let esp = device_info
         .partitions
         .into_iter()
@@ -70,7 +71,7 @@ pub fn find_colocated_esps(devices: &Vec<String>) -> Result<Option<Vec<String>>>
 /// Find bios_boot partition on the same device
 pub fn get_bios_boot_partition(device: &str) -> Result<Option<String>> {
     const BIOS_BOOT_TYPE_GUID: &str = "21686148-6449-6E6F-744E-656564454649";
-    let device_info = bootc_blockdev::partitions_of(Utf8Path::new(device))?;
+    let device_info = bootc_internal_blockdev::partitions_of(Utf8Path::new(device))?;
     let bios_boot = device_info
         .partitions
         .into_iter()

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{bail, Context, Result};
-use bootc_utils::CommandRunExt;
+use bootc_internal_utils::CommandRunExt;
 use cap_std::fs::Dir;
 use cap_std_ext::cap_std;
 use fn_error_context::context;

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -3,7 +3,7 @@ use std::os::unix::process::CommandExt;
 use std::process::Command;
 
 use anyhow::Result;
-use bootc_utils::CommandRunExt;
+use bootc_internal_utils::CommandRunExt;
 use fn_error_context::context;
 use rustix::fd::BorrowedFd;
 use serde::Deserialize;

--- a/src/filetree.rs
+++ b/src/filetree.rs
@@ -341,7 +341,7 @@ pub(crate) struct ApplyUpdateOptions {
     target_arch = "riscv64"
 ))]
 fn copy_dir(root: &openat::Dir, src: &str, dst: &str) -> Result<()> {
-    use bootc_utils::CommandRunExt;
+    use bootc_internal_utils::CommandRunExt;
     use std::os::unix::process::CommandExt;
     use std::process::Command;
 

--- a/src/grubconfigs.rs
+++ b/src/grubconfigs.rs
@@ -3,7 +3,7 @@ use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
-use bootc_utils::CommandRunExt;
+use bootc_internal_utils::CommandRunExt;
 use fn_error_context::context;
 use openat_ext::OpenatDirExt;
 


### PR DESCRIPTION
For now we'll continue to publish bootupd as a crate,
but I think we should eventually stop doing this.
    

Closes: https://github.com/coreos/bootupd/issues/964