### PR TITLE
ci: extend memory to fix the `OOMKilled` worker

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -38,7 +38,8 @@ codestyle: {
 
 // Build FCOS and do a kola basic run
 // FIXME update to main branch once https://github.com/coreos/fedora-coreos-config/pull/595 merges
-cosaPod(runAsUser: 0, memory: "4608Mi", cpu: "4") {
+// The FCOS build process is memory-intensive; 6GiB is needed to prevent OOM errors.
+cosaPod(runAsUser: 0, memory: "6144Mi", cpu: "4") {
   stage("Build FCOS") {
     checkout scm
     unstash 'build'


### PR DESCRIPTION
Fix CI error:
```
21:27:35  [PodInfo] coreos-ci/pod-50ada2f0-6a44-45a4-ad8c-d6f5e56a6aa2-ps3r1-b5tfm
21:27:35  Container [worker] terminated [OOMKilled] No message
21:27:35  Pod [Running][ContainersNotReady] containers with unready status: [worker]
```
Co-developed by mnguyen@redhat.com, aaradhak@redhat.com, tbueno@redhat.com