### PR TITLE
package: move to compare `version` instead of `timestamp`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "openssl",
  "os-release",
  "regex",
+ "rpm",
  "rustix 1.0.8",
  "serde",
  "serde_json",
@@ -368,7 +369,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -388,6 +389,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpio"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938e716cb1ade5d6c8f959c13a7248b889c07491fc7e41167c3afe20f8f0de1e"
 
 [[package]]
 name = "cpufeatures"
@@ -417,6 +424,34 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "enum-display-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f16ef37b2a9b242295d61a154ee91ae884afff6b8b933b486b12481cc58310ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "enum-primitive-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba7795da175654fe16979af73f81f26a8ea27638d8d9823d317016888a63dc4c"
+dependencies = [
+ "num-traits",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -477,7 +512,7 @@ checksum = "2cd66269887534af4b0c3e3337404591daa8dc8b9b2b3db71f9523beb4bafb41"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -628,6 +663,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,7 +698,7 @@ checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -689,7 +733,7 @@ dependencies = [
  "libc",
  "log",
  "nix 0.29.0",
- "nom",
+ "nom 8.0.0",
  "once_cell",
  "serde",
  "sha2",
@@ -731,6 +775,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +807,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -802,6 +862,16 @@ dependencies = [
 
 [[package]]
 name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
@@ -817,6 +887,81 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -887,7 +1032,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1046,6 +1191,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rpm"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "422ffe5b31ea4c7c76a361dc29b986e11fb6987313453088e1fd95f34ecc1ba6"
+dependencies = [
+ "bitflags 2.8.0",
+ "cpio",
+ "digest",
+ "enum-display-derive",
+ "enum-primitive-derive",
+ "hex",
+ "itertools",
+ "log",
+ "md-5",
+ "nom 7.1.3",
+ "num",
+ "num-derive",
+ "num-traits",
+ "sha1",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,7 +1286,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1130,6 +1299,17 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1187,6 +1367,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
@@ -1226,7 +1417,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1263,7 +1454,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1285,7 +1476,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1420,7 +1611,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -1442,7 +1633,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1627,5 +1818,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ openat-ext = ">= 0.2.2, < 0.3.0"
 openssl = "^0.10"
 os-release = "0.1.0"
 regex = "1.11.1"
+rpm = { version = "0.16.1", default-features = false }
 rustix = { version = "1.0.8", features = ["process", "fs"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"

--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -232,8 +232,11 @@ pub(crate) fn update(name: &str, rootcxt: &RootContext) -> Result<ComponentUpdat
     let sysroot = &rootcxt.sysroot;
     let update = component.query_update(sysroot)?;
     let update = match update.as_ref() {
-        Some(p) if inst.meta.can_upgrade_to(p) => p,
-        _ => return Ok(ComponentUpdateResult::AtLatestVersion),
+        Some(p) => match inst.meta.can_upgrade_to(p) {
+            std::cmp::Ordering::Less => p, // current < available -> upgrade
+            _ => return Ok(ComponentUpdateResult::AtLatestVersion),
+        },
+        None => return Ok(ComponentUpdateResult::AtLatestVersion),
     };
 
     ensure_writable_boot()?;

--- a/src/packagesystem.rs
+++ b/src/packagesystem.rs
@@ -1,9 +1,11 @@
+use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write;
 use std::path::Path;
 
 use anyhow::{bail, Context, Result};
 use chrono::prelude::*;
+use rpm::Evr;
 
 use crate::model::*;
 use crate::ostreeutil;
@@ -67,12 +69,182 @@ where
     rpm_parse_metadata(&rpmout.stdout)
 }
 
-#[test]
-fn test_parse_rpmout() {
-    let testdata = "grub2-efi-x64-1:2.06-95.fc38.x86_64,1681321788 grub2-efi-x64-1:2.06-95.fc38.x86_64,1681321788 shim-x64-15.6-2.x86_64,1657222566 shim-x64-15.6-2.x86_64,1657222566 shim-x64-15.6-2.x86_64,1657222566";
-    let parsed = rpm_parse_metadata(testdata.as_bytes()).unwrap();
-    assert_eq!(
-        parsed.version,
-        "grub2-efi-x64-1:2.06-95.fc38.x86_64,shim-x64-15.6-2.x86_64"
-    );
+fn parse_evr_map(input: &str) -> BTreeMap<String, Evr> {
+    input
+        .split(',')
+        .map(|pkg| {
+            // assume it is like "grub2-1:2.12-28.fc42,shim-15.8-3"
+            if !pkg.ends_with(std::env::consts::ARCH) {
+                let (name, version_release) = pkg.split_once('-').unwrap_or((pkg, ""));
+                let evr = Evr::parse(version_release);
+                return (name.to_string(), evr);
+            }
+
+            // assume it is like "grub2-efi-x64-1:2.12-28.fc42.x86_64,shim-x64-15.8-3.x86_64"
+            let nevra = rpm::Nevra::parse(pkg);
+            let _name = nevra.name();
+            // get name as "grub2" to match the usr/lib/efi path
+            let (name, _) = _name.split_once('-').unwrap_or((_name, ""));
+            (
+                name.to_string(),
+                Evr::new(
+                    nevra.epoch().to_string(),
+                    nevra.version().to_string(),
+                    nevra.release().to_string(),
+                ),
+            )
+        })
+        .collect()
+}
+
+// Implement Compare package versions function:
+// Return `Greater` if evr_a > evr_b,
+// Return `Less` if evr_a < evr_b,
+// Return `Equal` if evr_a == evr_b.
+fn compare_package_versions_impl(a: &str, b: &str) -> Vec<(String, Ordering)> {
+    let map_a = parse_evr_map(a);
+    let map_b = parse_evr_map(b);
+
+    // Compare package versions between `map_a` (current) and `map_b` (target).
+    // For each package in `map_b`:
+    // - If it exists in `map_a`, compare their versions and record the result.
+    // - If not found in `map_a`, assume it's a new package that should be upgraded.
+    let mut result = Vec::new();
+    for (name, evr_b) in map_b {
+        if let Some(evr_a) = map_a.get(&name) {
+            let cmp = evr_a.cmp(&evr_b);
+            result.push((name, cmp));
+        } else {
+            log::trace!("Found new package {name} in the target");
+            result.push((name, Ordering::Less));
+        }
+    }
+    result
+}
+
+// Compare package versions:
+// If any package is Ordering::Less, return Ordering::Less, means upgradable,
+// Else if any package is Ordering::Greater, return Ordering::Greater,
+// Else (all equal), return Ordering::Equal.
+pub(crate) fn compare_package_versions(a: &str, b: &str) -> Ordering {
+    // Fast path: if the two values are equal, skip detailed comparison
+    if a == b {
+        return Ordering::Equal;
+    }
+    let diffs = compare_package_versions_impl(a, b);
+
+    let mut has_less = false;
+    let mut has_greater = false;
+
+    for (_, ord) in &diffs {
+        match ord {
+            Ordering::Less => {
+                has_less = true;
+            }
+            Ordering::Greater => {
+                has_greater = true;
+            }
+            Ordering::Equal => {}
+        }
+    }
+
+    if has_less {
+        Ordering::Less
+    } else if has_greater {
+        Ordering::Greater
+    } else {
+        Ordering::Equal
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_rpmout() {
+        let testdata = "grub2-efi-x64-1:2.06-95.fc38.x86_64,1681321788 grub2-efi-x64-1:2.06-95.fc38.x86_64,1681321788 shim-x64-15.6-2.x86_64,1657222566 shim-x64-15.6-2.x86_64,1657222566 shim-x64-15.6-2.x86_64,1657222566";
+        let parsed = rpm_parse_metadata(testdata.as_bytes()).unwrap();
+        assert_eq!(
+            parsed.version,
+            "grub2-efi-x64-1:2.06-95.fc38.x86_64,shim-x64-15.6-2.x86_64"
+        );
+    }
+
+    #[test]
+    fn test_compare_package_versions() {
+        let current = "grub2-efi-x64-1:2.12-28.fc42.x86_64,shim-x64-15.8-3.x86_64";
+        let target = "grub2-efi-x64-1:2.12-29.fc42.x86_64,shim-x64-15.8-3.x86_64";
+        let ord = compare_package_versions(current, target);
+        assert_eq!(ord, Ordering::Less); // current < target
+
+        let ord = compare_package_versions(target, current);
+        assert_eq!(ord, Ordering::Greater);
+
+        let current = "grub2-efi-x64-1:2.12-28.fc42.x86_64,shim-x64-15.8-3.x86_64";
+        let target = "grub2-1:2.12-29.fc42,shim-15.8-3";
+        let ord = compare_package_versions(current, target);
+        assert_eq!(ord, Ordering::Less); // current < target
+
+        let ord = compare_package_versions(target, current);
+        assert_eq!(ord, Ordering::Greater);
+
+        let current = "grub2-1:2.12-28.fc42,shim-15.8-3";
+        let target = "grub2-1:2.12-28.fc42,shim-15.8-4";
+        let ord = compare_package_versions(current, target);
+        assert_eq!(ord, Ordering::Less); // current < target
+
+        let ord = compare_package_versions(target, current);
+        assert_eq!(ord, Ordering::Greater);
+
+        // The target includes new package, should upgrade
+        let current = "grub2-efi-x64-1:2.12-28.fc42.x86_64,shim-x64-15.8-3.x86_64";
+        let target = "grub2-efi-x64-1:2.12-28.fc42.x86_64,shim-x64-15.8-3.x86_64,test";
+        let ord = compare_package_versions(current, target);
+        assert_eq!(ord, Ordering::Less);
+
+        let ord = compare_package_versions(target, current);
+        assert_eq!(ord, Ordering::Equal);
+
+        // Not sure if this would happen
+        // current_grub2 > target_grub2
+        // current_shim < target_shim
+        // In this case there is Ordering::Less, return Ordering::Less
+        {
+            let current = "grub2-1:2.12-28.fc42,shim-15.8-3";
+            let target = "grub2-1:2.12-27.fc42,shim-15.8-4";
+            let ord = compare_package_versions(current, target);
+            assert_eq!(ord, Ordering::Less);
+
+            let ord = compare_package_versions(target, current);
+            assert_eq!(ord, Ordering::Less);
+        }
+
+        // Test Equal
+        {
+            let current = "grub2-efi-x64-1:2.12-28.fc42.x86_64,shim-x64-15.8-3.x86_64";
+            let target = "grub2-efi-x64-1:2.12-28.fc42.x86_64,shim-x64-15.8-3.x86_64";
+            let ord = compare_package_versions(current, target);
+            assert_eq!(ord, Ordering::Equal);
+
+            let current = "grub2-efi-x64-1:2.12-28.fc42.x86_64,shim-x64-15.8-3.x86_64";
+            let target = "grub2-1:2.12-28.fc42,shim-15.8-3";
+            let ord = compare_package_versions(current, target);
+            assert_eq!(ord, Ordering::Equal);
+
+            let current = "grub2-1:2.12-28.fc42,shim-15.8-3";
+            let target = "grub2-1:2.12-28.fc42,shim-15.8-3";
+            let ord = compare_package_versions(current, target);
+            assert_eq!(ord, Ordering::Equal);
+        }
+
+        // Test only grub2
+        let current = "grub2-1:2.12-28.fc42";
+        let target = "grub2-1:2.12-29.fc42";
+        let ord = compare_package_versions(current, target);
+        assert_eq!(ord, Ordering::Less);
+
+        let ord = compare_package_versions(target, current);
+        assert_eq!(ord, Ordering::Greater);
+    }
 }


### PR DESCRIPTION
Use `rpm::Evr` crate to parse and compare `version` when checking for update.

Inspired by Timothee's pointer:
https://github.com/coreos/bootupd/pull/938#issuecomment-3118960479
Fixes: https://github.com/coreos/bootupd/issues/933

Additional info:
Use rpm `0.16` instead of `0.17` as 1.84 does not support
feature `edition2024` that is requried by 0.17:
```
error: failed to parse manifest at `/root/.cargo/registry/src/
index.crates.io-6f17d22bba15001f/rpm-0.17.0/Cargo.toml`

Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`,
but that feature is not stabilized in this version of Cargo
(1.84.1 (66221abde 2024-11-19)).
```