### PR TITLE
[WIP] feat: enable systemd-boot support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 fastbuild*.qcow2
 _kola_temp
 .cosa
+*.img
+*.tar
+bootupctl

--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -96,7 +96,7 @@ pub(crate) fn install(
         let meta = component
             .install(&source_root, dest_root, device, update_firmware)
             .with_context(|| format!("installing component {}", component.name()))?;
-        log::info!("Installed {} {}", component.name(), meta.meta.version);
+        log::warn!("Installed {} {}", component.name(), meta.meta.version);
         state.installed.insert(component.name().into(), meta);
         // Yes this is a hack...the Component thing just turns out to be too generic.
         if let Some(vendor) = component.get_efi_vendor(&source_root)? {
@@ -303,7 +303,7 @@ pub(crate) fn adopt_and_update(
         return Ok(Some(update));
     } else {
         // Nothing adopted, skip
-        log::info!("Component '{}' skipped adoption", component.name());
+        log::warn!("Component '{}' skipped adoption", component.name());
         return Ok(None);
     }
 }

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -20,7 +20,6 @@ use openat_ext::OpenatDirExt;
 use os_release::OsRelease;
 use rustix::fd::BorrowedFd;
 use walkdir::WalkDir;
-use widestring::U16CString;
 
 use crate::bootupd::RootContext;
 use crate::freezethaw::fsfreeze_thaw_cycle;
@@ -47,9 +46,9 @@ pub(crate) const SHIM: &str = "shimx64.efi";
 #[cfg(target_arch = "riscv64")]
 pub(crate) const SHIM: &str = "shimriscv64.efi";
 
-/// Systemd boot loader info EFI variable names
-const LOADER_INFO_VAR_STR: &str = "LoaderInfo-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f";
-const STUB_INFO_VAR_STR: &str = "StubInfo-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f";
+// /// Systemd boot loader info EFI variable names
+// const LOADER_INFO_VAR_STR: &str = "LoaderInfo-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f";
+// const STUB_INFO_VAR_STR: &str = "StubInfo-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f";
 
 /// Return `true` if the system is booted via EFI
 pub(crate) fn is_efi_booted() -> Result<bool> {
@@ -169,69 +168,69 @@ fn get_product_name(sysroot: &Dir) -> Result<String> {
     Ok(release.name)
 }
 
-/// Convert a nul-terminated UTF-16 byte array to a String.
-fn string_from_utf16_bytes(slice: &[u8]) -> String {
-    // For some reason, systemd appends 3 nul bytes after the string.
-    // Drop the last byte if there's an odd number.
-    let size = slice.len() / 2;
-    let v: Vec<u16> = (0..size)
-        .map(|i| u16::from_ne_bytes([slice[2 * i], slice[2 * i + 1]]))
-        .collect();
-    U16CString::from_vec(v).unwrap().to_string_lossy()
-}
+// /// Convert a nul-terminated UTF-16 byte array to a String.
+// fn string_from_utf16_bytes(slice: &[u8]) -> String {
+//     // For some reason, systemd appends 3 nul bytes after the string.
+//     // Drop the last byte if there's an odd number.
+//     let size = slice.len() / 2;
+//     let v: Vec<u16> = (0..size)
+//         .map(|i| u16::from_ne_bytes([slice[2 * i], slice[2 * i + 1]]))
+//         .collect();
+//     U16CString::from_vec(v).unwrap().to_string_lossy()
+// }
 
-/// Read a nul-terminated UTF-16 string from an EFI variable.
-fn read_efi_var_utf16_string(name: &str) -> Option<String> {
-    let efivars = Path::new("/sys/firmware/efi/efivars");
-    if !efivars.exists() {
-        log::trace!("No efivars mount at {:?}", efivars);
-        return None;
-    }
-    let path = efivars.join(name);
-    if !path.exists() {
-        log::trace!("No EFI variable {name}");
-        return None;
-    }
-    match std::fs::read(&path) {
-        Ok(buf) => {
-            // Skip the first 4 bytes, those are the EFI variable attributes.
-            if buf.len() < 4 {
-                log::warn!("Read less than 4 bytes from {:?}", path);
-                return None;
-            }
-            Some(string_from_utf16_bytes(&buf[4..]))
-        }
-        Err(reason) => {
-            log::warn!("Failed reading {:?}: {reason}", path);
-            None
-        }
-    }
-}
+// /// Read a nul-terminated UTF-16 string from an EFI variable.
+// fn read_efi_var_utf16_string(name: &str) -> Option<String> {
+//     let efivars = Path::new("/sys/firmware/efi/efivars");
+//     if !efivars.exists() {
+//         log::trace!("No efivars mount at {:?}", efivars);
+//         return None;
+//     }
+//     let path = efivars.join(name);
+//     if !path.exists() {
+//         log::trace!("No EFI variable {name}");
+//         return None;
+//     }
+//     match std::fs::read(&path) {
+//         Ok(buf) => {
+//             // Skip the first 4 bytes, those are the EFI variable attributes.
+//             if buf.len() < 4 {
+//                 log::warn!("Read less than 4 bytes from {:?}", path);
+//                 return None;
+//             }
+//             Some(string_from_utf16_bytes(&buf[4..]))
+//         }
+//         Err(reason) => {
+//             log::warn!("Failed reading {:?}: {reason}", path);
+//             None
+//         }
+//     }
+// }
 
-/// Read the LoaderInfo EFI variable if it exists.
-fn get_loader_info() -> Option<String> {
-    read_efi_var_utf16_string(LOADER_INFO_VAR_STR)
-}
+// /// Read the LoaderInfo EFI variable if it exists.
+// fn get_loader_info() -> Option<String> {
+//     read_efi_var_utf16_string(LOADER_INFO_VAR_STR)
+// }
 
-/// Read the StubInfo EFI variable if it exists.
-fn get_stub_info() -> Option<String> {
-    read_efi_var_utf16_string(STUB_INFO_VAR_STR)
-}
+// /// Read the StubInfo EFI variable if it exists.
+// fn get_stub_info() -> Option<String> {
+//     read_efi_var_utf16_string(STUB_INFO_VAR_STR)
+// }
 
-/// Whether to skip adoption if a systemd bootloader is found.
-fn skip_systemd_bootloaders() -> bool {
-    if let Some(loader_info) = get_loader_info() {
-        if loader_info.starts_with("systemd") {
-            log::trace!("Skipping adoption for {:?}", loader_info);
-            return true;
-        }
-    }
-    if let Some(stub_info) = get_stub_info() {
-        log::trace!("Skipping adoption for {:?}", stub_info);
-        return true;
-    }
-    false
-}
+// /// Whether to skip adoption if a systemd bootloader is found.
+// fn skip_systemd_bootloaders() -> bool {
+//     if let Some(loader_info) = get_loader_info() {
+//         if loader_info.starts_with("systemd") {
+//             log::trace!("Skipping adoption for {:?}", loader_info);
+//             return true;
+//         }
+//     }
+//     if let Some(stub_info) = get_stub_info() {
+//         log::trace!("Skipping adoption for {:?}", stub_info);
+//         return true;
+//     }
+//     false
+// }
 
 impl Component for Efi {
     fn name(&self) -> &'static str {
@@ -244,11 +243,11 @@ impl Component for Efi {
             return Ok(None);
         };
 
-        // Don't adopt if the system is booted with systemd-boot or
-        // systemd-stub since those will be managed with bootctl.
-        if skip_systemd_bootloaders() {
-            return Ok(None);
-        }
+        // // Don't adopt if the system is booted with systemd-boot or
+        // // systemd-stub since those will be managed with bootctl.
+        // if skip_systemd_bootloaders() {
+        //     return Ok(None);
+        // }
         crate::component::query_adopt_state()
     }
 

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -16,10 +16,13 @@ use cap_std::fs::Dir;
 use cap_std_ext::cap_std;
 use chrono::prelude::*;
 use fn_error_context::context;
+use log::{info, warn};
 use openat_ext::OpenatDirExt;
 use os_release::OsRelease;
+use std::io::Write;
 use rustix::fd::BorrowedFd;
 use walkdir::WalkDir;
+use widestring::U16CString;
 
 use crate::bootupd::RootContext;
 use crate::freezethaw::fsfreeze_thaw_cycle;
@@ -45,10 +48,6 @@ pub(crate) const SHIM: &str = "shimx64.efi";
 
 #[cfg(target_arch = "riscv64")]
 pub(crate) const SHIM: &str = "shimriscv64.efi";
-
-// /// Systemd boot loader info EFI variable names
-// const LOADER_INFO_VAR_STR: &str = "LoaderInfo-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f";
-// const STUB_INFO_VAR_STR: &str = "StubInfo-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f";
 
 /// Return `true` if the system is booted via EFI
 pub(crate) fn is_efi_booted() -> Result<bool> {
@@ -152,6 +151,35 @@ impl Efi {
         clear_efi_target(&product_name)?;
         create_efi_boot_entry(device, espdir, vendordir, &product_name)
     }
+
+    /// Find a kernel and optional initramfs/uki file in the update directory for systemd-boot
+    fn find_kernel_and_initrd(dir: &openat::Dir) -> Result<(String, Option<String>)> {
+        let mut kernel: Option<String> = None;
+        let mut initrd: Option<String> = None;
+        log::warn!("Searching for kernel and initrd in update dir: {:?}", dir.recover_path());
+        for entry in dir.list_dir(".")? {
+            log::warn!("Found entry: {:?}", entry);
+            let entry = entry?;
+            let fname = entry.file_name().to_string_lossy();
+            if fname.starts_with("vmlinuz") || fname.ends_with(".efi") || fname.ends_with(".uki") {
+                log::warn!("Found kernel/UKI file: {}", fname);
+                if kernel.is_some() {
+                    log::warn!("Multiple kernel/UKI files found in update dir");
+                    bail!("Multiple kernel/UKI files found in update dir");
+                }
+                kernel = Some(fname.to_string());
+            } else if fname.starts_with("initrd") || fname.ends_with(".img") || fname.ends_with(".cpio.gz") {
+                log::warn!("Found initramfs file: {}", fname);
+                if initrd.is_some() {
+                    log::warn!("Multiple initramfs files found in update dir");
+                    bail!("Multiple initramfs files found in update dir");
+                }
+                initrd = Some(fname.to_string());
+            }
+        }
+        let kernel = kernel.ok_or_else(|| anyhow::anyhow!("No kernel or UKI file found in update dir"))?;
+        Ok((kernel, initrd))
+    }
 }
 
 #[context("Get product name")]
@@ -167,70 +195,6 @@ fn get_product_name(sysroot: &Dir) -> Result<String> {
     let release: OsRelease = OsRelease::new()?;
     Ok(release.name)
 }
-
-// /// Convert a nul-terminated UTF-16 byte array to a String.
-// fn string_from_utf16_bytes(slice: &[u8]) -> String {
-//     // For some reason, systemd appends 3 nul bytes after the string.
-//     // Drop the last byte if there's an odd number.
-//     let size = slice.len() / 2;
-//     let v: Vec<u16> = (0..size)
-//         .map(|i| u16::from_ne_bytes([slice[2 * i], slice[2 * i + 1]]))
-//         .collect();
-//     U16CString::from_vec(v).unwrap().to_string_lossy()
-// }
-
-// /// Read a nul-terminated UTF-16 string from an EFI variable.
-// fn read_efi_var_utf16_string(name: &str) -> Option<String> {
-//     let efivars = Path::new("/sys/firmware/efi/efivars");
-//     if !efivars.exists() {
-//         log::trace!("No efivars mount at {:?}", efivars);
-//         return None;
-//     }
-//     let path = efivars.join(name);
-//     if !path.exists() {
-//         log::trace!("No EFI variable {name}");
-//         return None;
-//     }
-//     match std::fs::read(&path) {
-//         Ok(buf) => {
-//             // Skip the first 4 bytes, those are the EFI variable attributes.
-//             if buf.len() < 4 {
-//                 log::warn!("Read less than 4 bytes from {:?}", path);
-//                 return None;
-//             }
-//             Some(string_from_utf16_bytes(&buf[4..]))
-//         }
-//         Err(reason) => {
-//             log::warn!("Failed reading {:?}: {reason}", path);
-//             None
-//         }
-//     }
-// }
-
-// /// Read the LoaderInfo EFI variable if it exists.
-// fn get_loader_info() -> Option<String> {
-//     read_efi_var_utf16_string(LOADER_INFO_VAR_STR)
-// }
-
-// /// Read the StubInfo EFI variable if it exists.
-// fn get_stub_info() -> Option<String> {
-//     read_efi_var_utf16_string(STUB_INFO_VAR_STR)
-// }
-
-// /// Whether to skip adoption if a systemd bootloader is found.
-// fn skip_systemd_bootloaders() -> bool {
-//     if let Some(loader_info) = get_loader_info() {
-//         if loader_info.starts_with("systemd") {
-//             log::trace!("Skipping adoption for {:?}", loader_info);
-//             return true;
-//         }
-//     }
-//     if let Some(stub_info) = get_stub_info() {
-//         log::trace!("Skipping adoption for {:?}", stub_info);
-//         return true;
-//     }
-//     false
-// }
 
 impl Component for Efi {
     fn name(&self) -> &'static str {
@@ -342,10 +306,11 @@ impl Component for Efi {
         device: &str,
         update_firmware: bool,
     ) -> Result<InstalledContent> {
+        log::warn!("Installing component: {}", self.name());
         let Some(meta) = get_component_update(src_root, self)? else {
             anyhow::bail!("No update metadata for component {} found", self.name());
         };
-        log::debug!("Found metadata {}", meta.version);
+        log::warn!("Found metadata {}", meta.version);
         let srcdir_name = component_updatedirname(self);
         let ft = crate::filetree::FileTree::new_from_dir(&src_root.sub_dir(&srcdir_name)?)?;
 
@@ -364,23 +329,94 @@ impl Component for Efi {
             self.mount_esp_device(Path::new(dest_root), Path::new(&esp_device))?
         };
 
+        let destpath_clone = destpath.clone();
+
         let destd = &openat::Dir::open(&destpath)
             .with_context(|| format!("opening dest dir {}", destpath.display()))?;
         validate_esp_fstype(destd)?;
+
+        // let using_systemd_boot = skip_systemd_bootloaders();
+        let using_systemd_boot = true;
 
         // TODO - add some sort of API that allows directly setting the working
         // directory to a file descriptor.
         std::process::Command::new("cp")
             .args(["-rp", "--reflink=auto"])
             .arg(&srcdir_name)
-            .arg(destpath)
+            .arg(&destpath)
             .current_dir(format!("/proc/self/fd/{}", src_root.as_raw_fd()))
             .run()?;
-        if update_firmware {
+
+        // Configure systemd-boot loader config/entry
+        if using_systemd_boot {
+            let loader_dir = destpath.join("loader");
+            if !loader_dir.exists() {
+                log::warn!("Creating systemd-boot loader directory at {}", loader_dir.display());
+                std::fs::create_dir_all(&loader_dir)
+                    .with_context(|| format!("creating systemd-boot loader directory {}", loader_dir.display()))?;
+            }
+            let entries_dir = loader_dir.join("entries");
+            log::warn!("Using systemd-boot, creating entries dir at {}", entries_dir.display());
+            std::fs::create_dir_all(&entries_dir)
+                .with_context(|| format!("creating entries dir {}", entries_dir.display()))?;
+            log::warn!("Installing systemd-boot entry in {}/bootupd.conf", entries_dir.display());
+            // Write loader.conf if it doesn't exist
+            let loader_conf_path = loader_dir.join("loader.conf");
+            if !loader_conf_path.exists() {
+                let mut loader_conf = std::fs::File::create(&loader_conf_path)
+                    .with_context(|| format!("creating loader.conf at {}", loader_conf_path.display()))?;
+                writeln!(loader_conf, "default auto")?;
+                writeln!(loader_conf, "timeout 20")?;
+                writeln!(loader_conf, "editor no")?;
+            }
+            log::warn!("Installed: {}/bootupd.conf", entries_dir.display());
+
+            // let sysroot = Dir::open_ambient_dir("/", cap_std::ambient_authority())?;
+            // let product_name = get_product_name(&sysroot).unwrap_or("Unknown Product".to_string());
+            // log::warn!("Get product name: '{product_name}'");
+
+            // Find the kernel/UKI and optional initramfs in the update dir
+            log::warn!(
+                "Searching for kernel and initrd in update dir: {:?}",
+                crate::model::BOOTUPD_UPDATES_DIR
+            );
+            let update_dir = src_root.sub_dir(&srcdir_name)
+                .context("opening update dir")?;
+            log::debug!("Searching for kernel and initrd in update dir: {:?}", update_dir.recover_path());
+            let (kernel_file, initrd_file) = Self::find_kernel_and_initrd(&update_dir)?;
+
+            log::warn!(
+                "Installing systemd-boot entry for kernel: {}, initrd: {:?}",
+                kernel_file, initrd_file
+            );
+            crate::systemd_boot_configs::install(
+                &destd,
+                true,
+                "Unknown Product",
+                &kernel_file,
+                initrd_file.as_deref(),
+            ).context("installing systemd-boot entry")?;
+        }
+
+        // If using systemd-boot, run `bootctl install` to set up the bootloader.
+        if using_systemd_boot {
+            log::warn!("Using systemd-boot, running bootctl install");
+            let status = std::process::Command::new("bootctl")
+                .args(["install", "--esp-path", destpath_clone.to_str().unwrap()])
+                .status()
+                .context("running bootctl install")?;
+            log::warn!("bootctl install status: {}", status);
+            if !status.success() {
+                bail!("bootctl install failed with status: {}", status);
+            }
+        }
+
+        if update_firmware && !using_systemd_boot {
             if let Some(vendordir) = self.get_efi_vendor(&src_root)? {
                 self.update_firmware(device, destd, &vendordir)?
             }
         }
+
         Ok(InstalledContent {
             meta,
             filetree: Some(ft),
@@ -714,8 +750,11 @@ fn get_efi_component_from_usr<'a>(
         .filter_map(|entry| {
             let entry = entry.ok()?;
             if !entry.file_type().is_dir() || entry.file_name() != "EFI" {
+                info!("Skipping non-directory or non-EFI entry: {}", entry.path().display());
                 return None;
             }
+
+            info!("Found EFI component at {}", entry.path().display());
 
             let abs_path = entry.path();
             let rel_path = abs_path.strip_prefix(sysroot).ok()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,7 @@ mod ostreeutil;
 mod packagesystem;
 mod sha512string;
 mod util;
+mod systemd_boot_configs;
 
 use clap::crate_name;
 

--- a/src/systemd_boot_configs.rs
+++ b/src/systemd_boot_configs.rs
@@ -1,0 +1,72 @@
+use anyhow::{Context, Result};
+use fn_error_context::context;
+use openat_ext::OpenatDirExt;
+
+const SYSTEMD_BOOT_ENTRIES_DIR: &str = "loader/entries";
+
+pub(crate) struct SystemdBootEntry {
+    title: String,
+    linux: String,
+    initrd: Option<String>,
+    options: String,
+}
+
+/// Install the systemd-boot entry files
+#[context("Installing systemd-boot entries")]
+pub(crate) fn install(
+    target_root: &openat::Dir,   // This should be mounted ESP root dir (not /boot inside ESP)
+    write_uuid: bool,
+    os_title: &str,
+    linux_path: &str,
+    initrd_path: Option<&str>,
+) -> Result<()> {
+    // Ensure /loader/entries exist on ESP root
+    if !target_root.exists(SYSTEMD_BOOT_ENTRIES_DIR)? {
+        target_root.create_dir(SYSTEMD_BOOT_ENTRIES_DIR, 0o700)?;
+    }
+
+    // Inspect root filesystem UUID - for root=UUID=... kernel parameter
+    let rootfs_meta = crate::filesystem::inspect_filesystem(target_root, ".")?;
+    let root_uuid = rootfs_meta
+        .uuid
+        .ok_or_else(|| anyhow::anyhow!("Failed to find UUID for root"))?;
+
+    // Compose entry config
+    let config = SystemdBootEntry {
+        title: os_title.to_string(),
+        // For UKI, path is relative to ESP root, e.g. /EFI/ukify.efi
+        linux: format!("/EFI/{}", linux_path.trim_start_matches('/')),
+        initrd: initrd_path.map(|p| format!("{}/{}", SYSTEMD_BOOT_ENTRIES_DIR, p)),
+        options: if write_uuid {
+            format!("root=UUID={} quiet", root_uuid)
+        } else {
+            "quiet".to_string()
+        },
+    };
+
+    let mut entry_content = format!("title {}\n", config.title);
+
+    if linux_path.ends_with(".efi") {
+        // UKI boot entry
+        log::warn!("Installing UKI entry: {}", config.linux);
+        entry_content.push_str(&format!("efi {}\n", config.linux));
+    } else {
+        // Kernel/initrd entry
+        entry_content.push_str(&format!("linux {}\n", config.linux));
+        if let Some(initrd) = &config.initrd {
+            entry_content.push_str(&format!("initrd {}\n", initrd));
+        }
+        entry_content.push_str(&format!("options {}\n", config.options));
+    }
+
+    // Write the entry file under /loader/entries/bootupd.conf on ESP root
+    let entries_dir = target_root.sub_dir(SYSTEMD_BOOT_ENTRIES_DIR)?;
+    entries_dir.write_file_contents(
+        "bootupd.conf",
+        0o644,
+        entry_content.as_bytes(),
+    ).context("Writing systemd-boot loader entry")?;
+    log::warn!("Installed: {}/bootupd.conf", SYSTEMD_BOOT_ENTRIES_DIR);
+
+    Ok(())
+}

--- a/tmp/Containerfile
+++ b/tmp/Containerfile
@@ -1,0 +1,21 @@
+FROM quay.io/fedora/fedora-bootc:42
+
+# RUN dnf remove -y grub2-efi grub2-common grub2-tools grub2-pc grub2-efi-x64 shim-x64 shim-x64-efi grub2-tools-minimal
+RUN dnf install -y \
+    systemd-boot \
+    systemd-ukify
+
+RUN set -x && \
+    KVER=$(rpm -q --qf '%{version}-%{release}.%{arch}\n' kernel | head -n 1) && \
+    KVER_SIMPLE=$(rpm -q --qf '%{version}' kernel) && \
+    mkdir -p /usr/lib/efi/sdboot/$KVER_SIMPLE/EFI && \
+    ukify build \
+    --linux=/usr/lib/modules/$KVER/vmlinuz \
+    --initrd=/usr/lib/modules/$KVER/initramfs.img \
+    --output /usr/lib/efi/sdboot/$KVER_SIMPLE/EFI/ukify.efi
+
+# COPY bootc /usr/bin/bootc
+COPY bootupctl /usr/bin/bootupctl
+
+RUN bootupctl backend generate-update-metadata -vvv
+# RUN rm /usr/bin/bootupctl

--- a/tmp/build.sh
+++ b/tmp/build.sh
@@ -1,0 +1,25 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+rm -f bootupctl
+cp ../target/debug/bootupd ./bootupctl
+podman build -f Containerfile -t fedora-sdboot:latest .
+rm -f fedora-sdboot.tar
+podman save -o fedora-sdboot.tar fedora-sdboot:latest
+IMAGE_ID=$(sudo podman load -i fedora-sdboot.tar | awk '/Loaded image:/ {print $3}')
+
+if [ ! -e ./bootable.img ] ; then
+    fallocate -l 20G bootable.img
+fi
+
+sudo podman run \
+    --rm --privileged --pid=host \
+    -it \
+    -v /sys/fs/selinux:/sys/fs/selinux \
+    -v /etc/containers:/etc/containers:Z \
+    -v /var/lib/containers:/var/lib/containers \
+    -v /dev:/dev \
+    -v .:/data:Z \
+    --security-opt label=type:unconfined_t \
+    $IMAGE_ID bootc install to-disk --via-loopback /data/bootable.img --filesystem ext4 --wipe


### PR DESCRIPTION
This is nowhere near ready, and I highly doubt any of this code will make it's way into bootupd without major refactoring...  I'm just trying to make something that works and start the feedback cycle early.

Info logs changed to warns as it was the easiest way to make them show up during `bootc install`.

TODO:
- [ ] Major refactoring
- [ ] Correctly detect (or accept as input) the product name
- [ ] Correctly detect whether to install with sd-boot or grub
- [ ] Boot into a composefs image (since ostree currently lacks support and boots to emergency mode)
- [ ] Everything else