### PR TITLE
packagesystem: make `rpm` as build-time configuration

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -18,6 +18,7 @@ parallel build: {
       stage("Unit tests") {
         shwrap("""
           dnf install -y grub2-tools-minimal
+          cargo test --features rpm
           cargo test
         """)
       }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ openat-ext = ">= 0.2.2, < 0.3.0"
 openssl = "^0.10"
 os-release = "0.1.0"
 regex = "1.11.2"
-rpm = { version = "0.16.1", default-features = false }
+rpm-rs = { package = "rpm", version = "0.16.1", default-features = false, optional = true }
 rustix = { version = "1.0.8", features = ["process", "fs"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
@@ -63,3 +63,7 @@ pre-release-commit-message = "cargo: bootupd release {{version}}"
 sign-commit = true
 sign-tag = true
 tag-message = "bootupd {{version}}"
+
+[features]
+default = []
+rpm = ["rpm-rs"]


### PR DESCRIPTION
This continuous from https://github.com/coreos/bootupd/pull/977,
inspired by Colin's https://github.com/coreos/bootupd/pull/977#discussion_r2279416177.