### PR TITLE
Add `versions` to `ContentMetadata`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,7 @@ dependencies = [
  "serde_json",
  "signal-hook-registry",
  "tempfile",
+ "uapi-version",
  "walkdir",
  "widestring",
 ]
@@ -1523,6 +1524,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "uapi-version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "849f6b1fe8a0fb07170737d7f3acf72cac5462fb3f4e86614474a49f7fac3b65"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ rustix = { version = "1.0.8", features = ["process", "fs"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 tempfile = "^3.21"
+uapi-version = "0.4.0"
 widestring = "1.2.0"
 walkdir = "2.3.2"
 signal-hook-registry = "1.4.6"

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -69,6 +69,7 @@ pub fn find_colocated_esps(devices: &Vec<String>) -> Result<Option<Vec<String>>>
 }
 
 /// Find bios_boot partition on the same device
+#[cfg(any(target_arch = "x86_64", target_arch = "powerpc64"))]
 pub fn get_bios_boot_partition(device: &str) -> Result<Option<String>> {
     const BIOS_BOOT_TYPE_GUID: &str = "21686148-6449-6E6F-744E-656564454649";
     let device_info = bootc_internal_blockdev::partitions_of(Utf8Path::new(device))?;
@@ -83,6 +84,7 @@ pub fn get_bios_boot_partition(device: &str) -> Result<Option<String>> {
 }
 
 /// Find all bios_boot partitions on the devices
+#[cfg(any(target_arch = "x86_64", target_arch = "powerpc64"))]
 pub fn find_colocated_bios_boot(devices: &Vec<String>) -> Result<Option<Vec<String>>> {
     // look for all bios_boot parts on those devices
     let mut bios_boots = Vec::new();

--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -155,7 +155,7 @@ type Components = BTreeMap<&'static str, Box<dyn Component>>;
 #[allow(clippy::box_default)]
 /// Return the set of known components; if `auto` is specified then the system
 /// filters to the target booted state.
-pub(crate) fn get_components_impl(auto: bool) -> Components {
+pub(crate) fn get_components_impl(_auto: bool) -> Components {
     let mut components = BTreeMap::new();
 
     fn insert_component(components: &mut Components, component: Box<dyn Component>) {
@@ -164,7 +164,7 @@ pub(crate) fn get_components_impl(auto: bool) -> Components {
 
     #[cfg(target_arch = "x86_64")]
     {
-        if auto {
+        if _auto {
             let is_efi_booted = crate::efi::is_efi_booted().unwrap();
             log::info!(
                 "System boot method: {}",

--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -145,6 +145,7 @@ fn get_static_config_meta() -> Result<ContentMetadata> {
     let self_meta = ContentMetadata {
         timestamp: self_bin_meta.modified()?.into(),
         version: crate_version!().into(),
+        versions: None,
     };
     Ok(self_meta)
 }

--- a/src/component.rs
+++ b/src/component.rs
@@ -167,6 +167,7 @@ pub(crate) fn query_adopt_state() -> Result<Option<Adoptable>> {
         let meta = ContentMetadata {
             timestamp: coreos_aleph.ts,
             version: coreos_aleph.aleph.version,
+            versions: None,
         };
         log::trace!("Adoptable: {:?}", &meta);
         return Ok(Some(Adoptable {
@@ -183,6 +184,7 @@ pub(crate) fn query_adopt_state() -> Result<Option<Adoptable>> {
         let meta = ContentMetadata {
             timestamp,
             version: "unknown".to_string(),
+            versions: None,
         };
         return Ok(Some(Adoptable {
             version: meta,

--- a/src/model_legacy.rs
+++ b/src/model_legacy.rs
@@ -49,6 +49,7 @@ impl ContentMetadata01 {
         NewContentMetadata {
             timestamp,
             version: self.version,
+            versions: None,
         }
     }
 }

--- a/src/packagesystem.rs
+++ b/src/packagesystem.rs
@@ -5,10 +5,37 @@ use std::path::Path;
 
 use anyhow::{bail, Context, Result};
 use chrono::prelude::*;
-use rpm::Evr;
+use serde::{Deserialize, Serialize};
+use uapi_version::Version;
 
 use crate::model::*;
 use crate::ostreeutil;
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct Module {
+    pub(crate) name: String,
+    pub(crate) rpm_evr: String,
+}
+
+impl Module {
+    pub(crate) fn rpm_evr(&self) -> Version {
+        Version::from(&self.rpm_evr)
+    }
+}
+
+impl Ord for Module {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.name
+            .cmp(&other.name) // Compare names first
+            .then_with(|| self.rpm_evr().cmp(&other.rpm_evr())) // If names equal, compare versions
+    }
+}
+
+impl PartialOrd for Module {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
 
 /// Parse the output of `rpm -q`
 fn rpm_parse_metadata(stdout: &[u8]) -> Result<ContentMetadata> {
@@ -40,9 +67,14 @@ fn rpm_parse_metadata(stdout: &[u8]) -> Result<ContentMetadata> {
         s.push_str(n);
         s
     });
+
+    // Map the version into Module struct
+    let mut modules_vec: Vec<Module> = pkgs.keys().map(|pkg_str| parse_evr(pkg_str)).collect();
+    modules_vec.sort_unstable();
     Ok(ContentMetadata {
         timestamp: **largest_timestamp,
         version,
+        versions: Some(modules_vec),
     })
 }
 
@@ -69,57 +101,66 @@ where
     rpm_parse_metadata(&rpmout.stdout)
 }
 
-fn parse_evr_map(input: &str) -> BTreeMap<String, Evr> {
-    input
-        .split(',')
-        .map(|pkg| {
-            // assume it is like "grub2-1:2.12-28.fc42,shim-15.8-3"
-            if !pkg.ends_with(std::env::consts::ARCH) {
-                let (name, version_release) = pkg.split_once('-').unwrap_or((pkg, ""));
-                let evr = Evr::parse(version_release);
-                return (name.to_string(), evr);
-            }
+fn parse_evr(pkg: &str) -> Module {
+    // assume it is "grub2-1:2.12-28.fc42" (from usr/lib/efi)
+    if !pkg.ends_with(std::env::consts::ARCH) {
+        let (name, evr) = pkg.split_once('-').unwrap_or((pkg, ""));
+        return Module {
+            name: name.to_string(),
+            rpm_evr: evr.to_string(),
+        };
+    }
 
-            // assume it is like "grub2-efi-x64-1:2.12-28.fc42.x86_64,shim-x64-15.8-3.x86_64"
-            let nevra = rpm::Nevra::parse(pkg);
-            let _name = nevra.name();
-            // get name as "grub2" to match the usr/lib/efi path
-            let (name, _) = _name.split_once('-').unwrap_or((_name, ""));
-            (
-                name.to_string(),
-                Evr::new(
-                    nevra.epoch().to_string(),
-                    nevra.version().to_string(),
-                    nevra.release().to_string(),
-                ),
-            )
-        })
-        .collect()
+    let (name_str, rpm_evr) = {
+        let nevra = rpm::Nevra::parse(pkg);
+        (nevra.name().to_string(), nevra.evr().to_string())
+    };
+
+    let (name, _) = name_str.split_once('-').unwrap_or((&name_str, ""));
+    Module {
+        name: name.to_string(),
+        rpm_evr,
+    }
 }
 
-// Implement Compare package versions function:
-// Return `Greater` if evr_a > evr_b,
-// Return `Less` if evr_a < evr_b,
-// Return `Equal` if evr_a == evr_b.
-fn compare_package_versions_impl(a: &str, b: &str) -> Vec<(String, Ordering)> {
-    let map_a = parse_evr_map(a);
-    let map_b = parse_evr_map(b);
+fn parse_evr_vec(input: &str) -> Vec<Module> {
+    let mut pkgs: Vec<Module> = input
+        .split(',')
+        .map(|pkg| parse_evr(pkg)) // parse_evr returns owned Package
+        .collect();
+    // Sort packages to ensure a consistent order for comparison, which is
+    // required by `compare_package_slices`.
+    pkgs.sort_unstable();
+    // Now that it's sorted, we can efficiently remove duplicates.
+    pkgs.dedup();
+    pkgs
+}
 
-    // Compare package versions between `map_a` (current) and `map_b` (target).
-    // For each package in `map_b`:
-    // - If it exists in `map_a`, compare their versions and record the result.
-    // - If not found in `map_a`, assume it's a new package that should be upgraded.
-    let mut result = Vec::new();
-    for (name, evr_b) in map_b {
-        if let Some(evr_a) = map_a.get(&name) {
-            let cmp = evr_a.cmp(&evr_b);
-            result.push((name, cmp));
-        } else {
-            log::trace!("Found new package {name} in the target");
-            result.push((name, Ordering::Less));
+pub(crate) fn compare_package_slices(a: &[Module], b: &[Module]) -> Ordering {
+    let mut has_greater = false;
+
+    // Assume it is in order
+    for (pkg_a, pkg_b) in a.iter().zip(b.iter()) {
+        match pkg_a.cmp(pkg_b) {
+            Ordering::Less => return Ordering::Less, // upgradable
+            Ordering::Greater => has_greater = true, // downgrade
+            Ordering::Equal => {}
         }
     }
-    result
+
+    // If all compared equal, longer slice wins
+    if a.len() < b.len() {
+        return Ordering::Less; // extra packages in b → upgrade
+    }
+    if a.len() > b.len() {
+        return Ordering::Greater; // extra packages in a → downgrade
+    }
+
+    if has_greater {
+        Ordering::Greater
+    } else {
+        Ordering::Equal
+    }
 }
 
 // Compare package versions:
@@ -131,30 +172,9 @@ pub(crate) fn compare_package_versions(a: &str, b: &str) -> Ordering {
     if a == b {
         return Ordering::Equal;
     }
-    let diffs = compare_package_versions_impl(a, b);
-
-    let mut has_less = false;
-    let mut has_greater = false;
-
-    for (_, ord) in &diffs {
-        match ord {
-            Ordering::Less => {
-                has_less = true;
-            }
-            Ordering::Greater => {
-                has_greater = true;
-            }
-            Ordering::Equal => {}
-        }
-    }
-
-    if has_less {
-        Ordering::Less
-    } else if has_greater {
-        Ordering::Greater
-    } else {
-        Ordering::Equal
-    }
+    let pkg_a = parse_evr_vec(a);
+    let pkg_b = parse_evr_vec(b);
+    compare_package_slices(&pkg_a, &pkg_b)
 }
 
 #[cfg(test)]
@@ -169,6 +189,50 @@ mod tests {
             parsed.version,
             "grub2-efi-x64-1:2.06-95.fc38.x86_64,shim-x64-15.6-2.x86_64"
         );
+        let expected_modules = vec![
+            Module {
+                name: "grub2".to_string(),
+                rpm_evr: "1:2.06-95.fc38".to_string(),
+            },
+            Module {
+                name: "shim".to_string(),
+                rpm_evr: "15.6-2".to_string(),
+            },
+        ];
+
+        assert_eq!(parsed.versions, Some(expected_modules));
+    }
+
+    #[test]
+    fn test_compare_package_slices() {
+        let a = vec![
+            Module {
+                name: "grub2".into(),
+                rpm_evr: "1:2.12-21.fc41".into(),
+            },
+            Module {
+                name: "shim".into(),
+                rpm_evr: "15.8-3".into(),
+            },
+        ];
+        let b = vec![
+            Module {
+                name: "grub2".into(),
+                rpm_evr: "1:2.12-28.fc41".into(),
+            },
+            Module {
+                name: "shim".into(),
+                rpm_evr: "15.8-3".into(),
+            },
+        ];
+        let ord = compare_package_slices(&a, &b);
+        assert_eq!(ord, Ordering::Less);
+
+        let ord = compare_package_slices(&b, &a);
+        assert_eq!(ord, Ordering::Greater);
+
+        let ord = compare_package_slices(&a, &a);
+        assert_eq!(ord, Ordering::Equal);
     }
 
     #[test]
@@ -204,7 +268,7 @@ mod tests {
         assert_eq!(ord, Ordering::Less);
 
         let ord = compare_package_versions(target, current);
-        assert_eq!(ord, Ordering::Equal);
+        assert_eq!(ord, Ordering::Greater);
 
         // Not sure if this would happen
         // current_grub2 > target_grub2

--- a/tests/fixtures/example-state-versions-v0.json
+++ b/tests/fixtures/example-state-versions-v0.json
@@ -1,0 +1,73 @@
+{
+  "installed": {
+    "BIOS": {
+      "meta": {
+        "timestamp": "2025-08-16T07:47:29Z",
+        "version": "grub2-tools-1:2.12-41.fc44.x86_64",
+        "versions": [
+          {
+            "name": "grub2",
+            "rpm_evr": "1:2.12-41.fc44"
+          }
+        ]
+      },
+      "filetree": null,
+      "adopted-from": null
+    },
+    "EFI": {
+      "meta": {
+        "timestamp": "2025-08-20T08:48:03.555492819Z",
+        "version": "grub2-1:2.12-41.fc44,shim-15.8-4",
+        "versions": [
+          {
+            "name": "grub2",
+            "rpm_evr": "1:2.12-41.fc44"
+          },
+          {
+            "name": "shim",
+            "rpm_evr": "15.8-4"
+          }
+        ]
+      },
+      "filetree": {
+        "children": {
+          "BOOT/BOOTX64.EFI": {
+            "size": 949424,
+            "sha512": "sha512:cc23d8c3cb2dcf749075268b77eb796fb430182cbbc04171ded14d43e32b4a5cdeeb1a08666ee0e288bd37d63f657a9af5e7f2012dd70694d11212d705c60b42"
+          },
+          "BOOT/fbx64.efi": {
+            "size": 87712,
+            "sha512": "sha512:44ea56e91bc6de46f276ca547f27266548a06766eb62d7fb1151a8033e67e36002dfa8a88dc7e968a002983447472256bd67a9cd85c640803e43bde359f01733"
+          },
+          "fedora/BOOTX64.CSV": {
+            "size": 110,
+            "sha512": "sha512:0c29b8ae73171ef683ba690069c1bae711e130a084a81169af33a83dfbae4e07d909c2482dbe89a96ab26e171f17c53f1de8cb13d558bc1535412ff8accf253f"
+          },
+          "fedora/grubx64.efi": {
+            "size": 4046320,
+            "sha512": "sha512:27444e76e95c85e2c7c042d89477867e7ecaec5a0066cae058366722fb76d41c923e85746a7fe31454f53de1bab3259ee881e2d5db38dc4d86d5f40c0137e03e"
+          },
+          "fedora/mmx64.efi": {
+            "size": 847976,
+            "sha512": "sha512:2223703a8f40620655928a5237dfb8f7273aef06fdfa9d5517d963869936f4a1b09ec805d8437bdf9c72e0cdf213e96eebd2d607981951057801c54fb455d013"
+          },
+          "fedora/shim.efi": {
+            "size": 949424,
+            "sha512": "sha512:cc23d8c3cb2dcf749075268b77eb796fb430182cbbc04171ded14d43e32b4a5cdeeb1a08666ee0e288bd37d63f657a9af5e7f2012dd70694d11212d705c60b42"
+          },
+          "fedora/shimx64.efi": {
+            "size": 949424,
+            "sha512": "sha512:cc23d8c3cb2dcf749075268b77eb796fb430182cbbc04171ded14d43e32b4a5cdeeb1a08666ee0e288bd37d63f657a9af5e7f2012dd70694d11212d705c60b42"
+          }
+        }
+      },
+      "adopted-from": null
+    }
+  },
+  "pending": null,
+  "static-configs": {
+    "timestamp": "1970-01-01T00:00:00Z",
+    "version": "0.2.29",
+    "versions": null
+  }
+}

--- a/tests/kola/test-bootupd
+++ b/tests/kola/test-bootupd
@@ -67,8 +67,11 @@ rm -v ${ostefi}/shim.efi
 echo bootupd-test-changes >> ${ostefi}/grubx64.efi
 /usr/libexec/bootupd generate-update-metadata /
 ver=$(jq -r .version < ${bootupdir}/EFI.json)
+vers=$(jq -r .versions < ${bootupdir}/EFI.json)
+test='[{"name": "test", "rpm_evr": ""}]'
+new=$(echo "$vers" "$test" | jq -s add)
 cat >ver.json << EOF
-{ "version": "${ver},test", "timestamp": "$(date -u --iso-8601=seconds)" }
+{ "version": "${ver},test", "versions": ${new}, "timestamp": "$(date -u --iso-8601=seconds)" }
 EOF
 jq -s add ${bootupdir}/EFI.json ver.json > new.json
 mv new.json ${bootupdir}/EFI.json

--- a/tests/tests/move-content-to-usr.sh
+++ b/tests/tests/move-content-to-usr.sh
@@ -14,13 +14,13 @@ if [ ! -d "/usr/lib/efi" ]; then
     suffix="aa64"
   fi
 
-  grub_ver=$(rpm -qa grub2-efi-${suffix} --queryformat '%{VERSION}-%{RELEASE}')
-  mkdir -p /usr/lib/efi/grub2/${grub_ver}/EFI/centos
-  mv ${updates}/EFI/centos/grub${suffix}.efi /usr/lib/efi/grub2/${grub_ver}/EFI/centos/
+  grub_evr=$(rpm -qa grub2-efi-${suffix} --queryformat '%{EPOCH}:%{VERSION}-%{RELEASE}')
+  mkdir -p /usr/lib/efi/grub2/${grub_evr}/EFI/centos
+  mv ${updates}/EFI/centos/grub${suffix}.efi /usr/lib/efi/grub2/${grub_evr}/EFI/centos/
 
-  shim_ver=$(rpm -qa shim-${suffix} --queryformat '%{VERSION}-%{RELEASE}')
-  mkdir -p /usr/lib/efi/shim/${shim_ver}/EFI/
-  mv ${updates}/EFI /usr/lib/efi/shim/${shim_ver}/
+  shim_vr=$(rpm -qa shim-${suffix} --queryformat '%{VERSION}-%{RELEASE}')
+  mkdir -p /usr/lib/efi/shim/${shim_vr}/EFI/
+  mv ${updates}/EFI /usr/lib/efi/shim/${shim_vr}/
 else
   rm -rf ${updates}/EFI
 fi


### PR DESCRIPTION
packagesystem: add struct `Module` about package name and evr

Also add `uapi_version::Version` to parse versions according to
Colin's comment https://github.com/coreos/bootupd/pull/983#discussion_r2284399377

---

Add `versions` to `ContentMetadata`

Inspired by Colin's comment https://github.com/coreos/bootupd/pull/977#discussion_r2278838151
We need `versions` to save struct like:
```
  "versions": [
    {"name": "pkg1", "rpm-evr": "1.0"},
    {"name": "pkg2", "rpm-evr": "2.0"}
  ]
```
Then we read and compare versions, do not need to parse the
version in str format.

Co-worked by walters@verbum.org