### PR TITLE
ci: fix failed ci workflow

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -56,6 +56,7 @@ cosaPod(runAsUser: 0, memory: "7168Mi", cpu: "4") {
       rmdir insttree
       cosa fetch
       cosa build
+      cosa osbuild qemu
       cosa osbuild metal4k
     """)
   }
@@ -71,7 +72,7 @@ cosaPod(runAsUser: 0, memory: "7168Mi", cpu: "4") {
     }
     stage("Kola testing") {
       // The previous e2e leaves things only having built an ostree update
-      shwrap("cosa build")
+      shwrap("cosa build && cosa osbuild qemu")
       // bootupd really can't break upgrades for the OS
       kola(cosaDir: "${env.WORKSPACE}", extraArgs: "ext.*bootupd*", skipUpgrade: true, skipBasicScenarios: true)
     }

--- a/ci/prow/fcos-e2e.sh
+++ b/ci/prow/fcos-e2e.sh
@@ -6,4 +6,5 @@ export COSA_SKIP_OVERLAY=1
 cosa init --force https://github.com/coreos/fedora-coreos-config/
 cosa fetch
 cosa build
+cosa osbuild qemu
 cosa kola run --qemu-firmware uefi 'ext.bootupd.*'

--- a/tests/e2e-update/e2e-update.sh
+++ b/tests/e2e-update/e2e-update.sh
@@ -54,6 +54,7 @@ if test -z "${e2e_skip_build:-}"; then
     # Version from F42 prior to GA
     add_override grub2-2.12-26.fc42
     runv cosa build
+    runv cosa osbuild qemu
     prev_image=$(runv cosa meta --image-path qemu)
     # Modify manifest to include `test-bootupd-payload` RPM
     runv git -C src/config checkout manifest.yaml # first make sure it's clean


### PR DESCRIPTION
According to https://github.com/coreos/coreos-assembler/commit/18b1ec454230a8a9e76a9ea33f6d137ececc5944 and https://redhat-internal.slack.com/archives/C08RWRUQ18T/p1755546661923769, `cosa build` will just get the ociarchive, need to run `cosa osbuild qemu` to get a built qemu.