### PR TITLE
efi: Extend `get_efi_vendor()` to support `usr/lib/efi`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,11 @@ FROM $base
 # Clean out the default to ensure we're using our updated content
 RUN rpm -e bootupd
 COPY --from=build /out/ /
+# Remove /var/roothome as workaround
+RUN <<EORUN
+set -xeuo pipefail
+[ -d /var/roothome ] && rm -rf /var/roothome
+EORUN
 # Sanity check this too
 RUN bootc container lint --fatal-warnings
 

--- a/src/bios.rs
+++ b/src/bios.rs
@@ -108,12 +108,14 @@ impl Component for Bios {
 
     fn install(
         &self,
-        src_root: &openat::Dir,
+        src_root: &str,
         dest_root: &str,
         device: &str,
         _update_firmware: bool,
     ) -> Result<InstalledContent> {
-        let Some(meta) = get_component_update(src_root, self)? else {
+        let src_dir = openat::Dir::open(src_root)
+            .with_context(|| format!("opening source directory {src_root}"))?;
+        let Some(meta) = get_component_update(&src_dir, self)? else {
             anyhow::bail!("No update metadata for component {} found", self.name());
         };
 

--- a/src/bios.rs
+++ b/src/bios.rs
@@ -265,7 +265,7 @@ impl Component for Bios {
         Ok(ValidationResult::Skip)
     }
 
-    fn get_efi_vendor(&self, _: &openat::Dir) -> Result<Option<String>> {
+    fn get_efi_vendor(&self, _: &str) -> Result<Option<String>> {
         Ok(None)
     }
 }

--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -94,7 +94,7 @@ pub(crate) fn install(
         }
 
         let meta = component
-            .install(&source_root_dir, dest_root, device, update_firmware)
+            .install(&source_root, dest_root, device, update_firmware)
             .with_context(|| format!("installing component {}", component.name()))?;
         log::info!("Installed {} {}", component.name(), meta.meta.version);
         state.installed.insert(component.name().into(), meta);
@@ -118,7 +118,7 @@ pub(crate) fn install(
             ))]
             crate::grubconfigs::install(
                 sysroot,
-                Some(&source_root),
+                Some(&source_root_dir),
                 installed_efi_vendor.as_deref(),
                 uuid,
             )?;

--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -53,7 +53,7 @@ pub(crate) fn install(
     // TODO: Change this to an Option<&str>; though this probably balloons into having
     // DeviceComponent and FileBasedComponent
     let device = device.unwrap_or("");
-    let source_root = openat::Dir::open(source_root).context("Opening source root")?;
+    let source_root_dir = openat::Dir::open(source_root).context("Opening source root")?;
     SavedState::ensure_not_present(dest_root)
         .context("failed to install, invalid re-install attempted")?;
 
@@ -94,7 +94,7 @@ pub(crate) fn install(
         }
 
         let meta = component
-            .install(&source_root, dest_root, device, update_firmware)
+            .install(&source_root_dir, dest_root, device, update_firmware)
             .with_context(|| format!("installing component {}", component.name()))?;
         log::info!("Installed {} {}", component.name(), meta.meta.version);
         state.installed.insert(component.name().into(), meta);

--- a/src/component.rs
+++ b/src/component.rs
@@ -51,7 +51,7 @@ pub(crate) trait Component {
     /// This will be run during a disk image build process.
     fn install(
         &self,
-        src_root: &openat::Dir,
+        src_root: &str,
         dest_root: &str,
         device: &str,
         update_firmware: bool,
@@ -200,18 +200,25 @@ mod tests {
     fn test_get_efi_vendor() -> Result<()> {
         let td = tempfile::tempdir()?;
         let tdp = td.path();
-        let tdp_updates = tdp.join("usr/lib/bootupd/updates");
-        let td = tdp.to_string_lossy();
-        std::fs::create_dir_all(tdp_updates.join("EFI/BOOT"))?;
-        std::fs::create_dir_all(tdp_updates.join("EFI/fedora"))?;
-        std::fs::create_dir_all(tdp_updates.join("EFI/centos"))?;
-        std::fs::write(
-            tdp_updates.join("EFI/fedora").join(crate::efi::SHIM),
-            "shim data",
+        let tdupdates = "usr/lib/bootupd/updates/EFI";
+        let tdir = openat::Dir::open(tdp)?;
+        let td = tdp.to_str().unwrap();
+
+        tdir.ensure_dir_all(tdupdates, 0o755)?;
+        let efi = tdir.sub_dir(tdupdates)?;
+        efi.create_dir("BOOT", 0o755)?;
+        efi.create_dir("fedora", 0o755)?;
+        efi.create_dir("centos", 0o755)?;
+
+        efi.write_file_contents(
+            format!("fedora/{}", crate::efi::SHIM),
+            0o644,
+            "shim data".as_bytes(),
         )?;
-        std::fs::write(
-            tdp_updates.join("EFI/centos").join(crate::efi::SHIM),
-            "shim data",
+        efi.write_file_contents(
+            format!("centos/{}", crate::efi::SHIM),
+            0o644,
+            "shim data".as_bytes(),
         )?;
 
         let all_components = crate::bootupd::get_components();
@@ -223,34 +230,36 @@ mod tests {
             if component.name() == "EFI" {
                 let x = component.get_efi_vendor(&td);
                 assert_eq!(x.is_err(), true);
-                std::fs::remove_dir_all(tdp_updates.join("EFI/centos"))?;
+                efi.remove_all("centos")?;
                 assert_eq!(component.get_efi_vendor(&td)?, Some("fedora".to_string()));
                 {
-                    let td_usr = tdp.join("usr/lib/efi");
-                    let td_vendor = td_usr.join("shim/15.8-3/EFI/centos");
-                    std::fs::create_dir_all(&td_vendor)?;
-                    std::fs::write(td_vendor.join(crate::efi::SHIM), "shim data")?;
+                    let td_vendor = "usr/lib/efi/shim/15.8-3/EFI/centos";
+                    tdir.ensure_dir_all(td_vendor, 0o755)?;
+                    let shim_dir = tdir.sub_dir(td_vendor)?;
+                    shim_dir.write_file_contents(
+                        crate::efi::SHIM,
+                        0o644,
+                        "shim data".as_bytes(),
+                    )?;
+
                     // usr/lib/efi wins and get 'centos'
-                    assert_eq!(
-                        component.get_efi_vendor(&tdp.to_string_lossy())?,
-                        Some("centos".to_string())
-                    );
+                    assert_eq!(component.get_efi_vendor(&td)?, Some("centos".to_string()));
                     // find directly from usr/lib/efi and get 'centos'
+                    let td_usr = format!("{td}/usr/lib/efi");
                     assert_eq!(
-                        component.get_efi_vendor(&td_usr.to_string_lossy())?,
+                        component.get_efi_vendor(&td_usr)?,
                         Some("centos".to_string())
                     );
                     // find directly from updates and get 'fedora'
-                    let td_efi = tdp.join(component_updatedirname(&**component));
+                    let td_efi =
+                        format!("{td}/{}", component_updatedirname(&**component).display());
                     assert_eq!(
-                        component.get_efi_vendor(&td_efi.to_string_lossy())?,
+                        component.get_efi_vendor(&td_efi)?,
                         Some("fedora".to_string())
                     );
-                    std::fs::remove_dir_all(&td_usr)?;
-                    std::fs::remove_dir_all(&tdp_updates)?;
-                    let err = component
-                        .get_efi_vendor(&td_usr.to_string_lossy())
-                        .unwrap_err();
+                    tdir.remove_all("usr/lib/efi")?;
+                    tdir.remove_all(tdupdates)?;
+                    let err = component.get_efi_vendor(&td_usr).unwrap_err();
                     assert_eq!(err.to_string(), "Failed to find valid target path");
                 }
             }


### PR DESCRIPTION
Prepare for step2 (in https://github.com/coreos/bootupd/issues/926) to install efi files from `usr/lib/efi`