### PR TITLE
efi: Get the correct esp on multipath when install

### DIFF
--- a/src/efi.rs
+++ b/src/efi.rs
@@ -163,8 +163,9 @@ impl Efi {
         }
 
         // Check shim exists and return earlier if not
-        if espdir.exists(format!("{vendordir}/{SHIM}"))? {
-            anyhow::bail!("Failed to find {SHIM}");
+        let shim_path = format!("EFI/{vendordir}/{SHIM}");
+        if !espdir.exists(&shim_path)? {
+            anyhow::bail!("Failed to find {shim_path}");
         }
         let loader = format!("\\EFI\\{vendordir}\\{SHIM}");
 
@@ -176,7 +177,7 @@ impl Efi {
 
         // clear all the boot entries that match the target name
         clear_efi_target(&product_name)?;
-        create_efi_boot_entry(device, &esp_part_num, &loader, &product_name)
+        create_efi_boot_entry(device, esp_part_num.trim(), &loader, &product_name)
     }
 }
 


### PR DESCRIPTION
efi: Check shim exists and return earlier if not found

---

efi: Get the correct esp on multipath

Get pointer from Colin:
```
what we need to do here instead is "peel" through the multipath 
to find the block device(s) backing it, and then pick one of those.
```
When I do testing using mpath or backing device, find the 
results are the same, so I use mpath instead.

As there is no partition attribute on multipath env, this leads
error when install on multipath.
Fixes: https://issues.redhat.com/browse/RHEL-81039