### PR TITLE
bootupd: Handle component removal when doing updates

### DIFF
--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -391,7 +391,12 @@ pub(crate) fn status() -> Result<Status> {
         // adoptable list, and adoption proceeds automatically.
         //
         // Therefore, calling `query_adopt_state()` alone is sufficient.
-        if let Some(adopt_ver) = crate::component::query_adopt_state()? {
+        if let Some(adopt_ver) = component::query_adopt_state()? {
+            let component = component::new_from_name(&name)?;
+            // Skip if the update metadata could not be found
+            if component.query_update(&sysroot)?.is_none() {
+                continue;
+            };
             ret.adoptable.insert(name.to_string(), adopt_ver);
         } else {
             log::trace!("Not adoptable: {}", name);

--- a/tests/kola/test-bootupd
+++ b/tests/kola/test-bootupd
@@ -115,6 +115,13 @@ bootupctl update | tee out.txt
 assert_file_has_content_literal out.txt 'No update available for any component'
 assert_not_file_has_content_literal out.txt 'Updated EFI'
 
+# Verify that we skipped update if update metadata not found
+mount -o remount,rw /boot
+rm -f /boot/bootupd-state.json ${bootupdir}/BIOS.json
+bootupctl update | tee out.txt
+assert_file_has_content out.txt 'Adopted and updated: EFI: grub2-.*'
+assert_not_file_has_content out.txt 'Adopted and updated: BIOS:'
+
 echo "some additions" >> ${tmpefisubdir}/${shimx64}
 if bootupctl validate 2>err.txt; then
   fatal "unexpectedly passed validation"


### PR DESCRIPTION
When doing the updates, should consider that if one component is removed, we should not update it any more.
See https://github.com/coreos/bootupd/issues/1011