### PR TITLE
Update will fail if update metadata is missing for the current boot type

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -67,7 +67,7 @@ cosaPod(memory: "7168Mi", cpu: "4") {
       // The previous e2e leaves things only having built an ostree update
       shwrap("cosa build && cosa osbuild qemu")
       // bootupd really can't break upgrades for the OS
-      kola(cosaDir: "${env.WORKSPACE}", extraArgs: "ext.*bootupd*", skipUpgrade: true, skipBasicScenarios: true)
+      kola(cosaDir: "${env.WORKSPACE}", extraArgs: "ext.*bootupd* --qemu-firmware=uefi", skipUpgrade: true, skipBasicScenarios: true)
     }
   } finally {
     archiveArtifacts allowEmptyArchive: true, artifacts: 'tmp/console.txt'

--- a/src/bios.rs
+++ b/src/bios.rs
@@ -243,7 +243,12 @@ impl Component for Bios {
     }
 
     fn query_update(&self, sysroot: &openat::Dir) -> Result<Option<ContentMetadata>> {
-        get_component_update(sysroot, self)
+        let content_metadata = get_component_update(sysroot, self)?;
+        // Failed as expected if booted with BIOS and no update metadata
+        if content_metadata.is_none() && !sysroot.exists("sys/firmware/efi")? {
+            anyhow::bail!("Failed to find BIOS update metadata");
+        }
+        Ok(content_metadata)
     }
 
     fn run_update(&self, rootcxt: &RootContext, _: &InstalledContent) -> Result<InstalledContent> {

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -551,7 +551,12 @@ impl Component for Efi {
     }
 
     fn query_update(&self, sysroot: &openat::Dir) -> Result<Option<ContentMetadata>> {
-        get_component_update(sysroot, self)
+        let content_metadata = get_component_update(sysroot, self)?;
+        // Failed as expected if booted with EFI and no update metadata
+        if content_metadata.is_none() && is_efi_booted()? {
+            anyhow::bail!("Failed to find EFI update metadata");
+        }
+        Ok(content_metadata)
     }
 
     fn validate(&self, current: &InstalledContent) -> Result<ValidationResult> {

--- a/tests/kola/test-bootupd
+++ b/tests/kola/test-bootupd
@@ -35,6 +35,19 @@ prepare_efi_update() {
   rm -rf ${bootupdir}/EFI.json
 }
 
+# backup: update_metadata_move EFI EFI-bak
+# restore: update_metadata_move EFI-bak EFI
+update_metadata_move() {
+  local src="${bootupdir}/$1.json"
+  local dst="${bootupdir}/$2.json"
+
+  [ -w "$bootupdir" ]
+  [ -f "$src" ]
+  [ ! -e "$dst" ]
+
+  mv -- "$src" "$dst"
+}
+
 # Find the files under usr/lib/efi after transferred
 shim_path=$(find ${efilib} -name shim.efi)
 shimx64_path=$(find ${efilib} -name ${shimx64})
@@ -115,12 +128,39 @@ bootupctl update | tee out.txt
 assert_file_has_content_literal out.txt 'No update available for any component'
 assert_not_file_has_content_literal out.txt 'Updated EFI'
 
-# Verify that we skipped update if update metadata not found
 mount -o remount,rw /boot
-rm -f /boot/bootupd-state.json ${bootupdir}/BIOS.json
-bootupctl update | tee out.txt
-assert_file_has_content out.txt 'Adopted and updated: EFI: grub2-.*'
-assert_not_file_has_content out.txt 'Adopted and updated: BIOS:'
+rm -f /boot/bootupd-state.json
+
+if [ -d /sys/firmware/efi ]; then
+  # EFI boot: verify update failed if metadata is missing EFI.json
+  # Backup EFI.json and restore it later, or validate will fail
+  update_metadata_move EFI EFI-bak
+  if bootupctl update 2>err.txt; then
+    fatal "Should fail as missing EFI update metadata (booted with EFI)"
+  fi
+  update_metadata_move EFI-bak EFI
+
+  # Should succeed if BIOS metadata is missing
+  rm -f ${bootupdir}/BIOS.json
+  bootupctl update | tee out.txt
+  assert_file_has_content out.txt 'Adopted and updated: EFI:'
+  assert_not_file_has_content out.txt 'Adopted and updated: BIOS:'
+
+else
+  # BIOS boot: verify update failed if metadata is missing BIOS.json
+  # Backup BIOS.json and restore it later, or validate will fail
+  update_metadata_move BIOS BIOS-bak
+  if bootupctl update 2>err.txt; then
+    fatal "Should fail as missing BIOS update metadata (booted with BIOS)"
+  fi
+  update_metadata_move BIOS-bak BIOS
+
+  # Should succeed if EFI metadata is missing
+  rm -f ${bootupdir}/EFI.json
+  bootupctl update | tee out.txt
+  assert_file_has_content out.txt 'Adopted and updated: BIOS:'
+  assert_not_file_has_content out.txt 'Adopted and updated: EFI:'
+fi
 
 echo "some additions" >> ${tmpefisubdir}/${shimx64}
 if bootupctl validate 2>err.txt; then


### PR DESCRIPTION
Fixes https://github.com/coreos/bootupd/issues/1035