### PR TITLE
Revert "efi: require minimum of 2 components for update metadata generation"

### DIFF
--- a/src/efi.rs
+++ b/src/efi.rs
@@ -525,10 +525,6 @@ impl Component for Efi {
         if let Some(efi_components) =
             get_efi_component_from_usr(Utf8Path::from_path(sysroot_path).unwrap(), EFILIB)?
         {
-            // Confirm EFI has at least two components grub2 & shim
-            // See https://github.com/coreos/bootupd/issues/994
-            assert!(efi_components.len() > 1);
-
             let mut packages = Vec::new();
             let mut modules_vec: Vec<Module> = vec![];
             for efi in efi_components {


### PR DESCRIPTION
This reverts commit e44ba4acda4c0e791d042db33f33dd64f52f17b9.

See discussions in https://github.com/coreos/bootupd/issues/1040