### PR TITLE
ci: Add crates.io trusted publishing on tag push

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -11,6 +11,8 @@ The release process follows the usual PR-and-review flow, allowing an external r
 
 In order to ease downstream packaging of Rust binaries, an archive of vendored dependencies is also provided (only relevant for offline builds).
 
+crates.io publishing uses [trusted publishing](https://crates.io/docs/trusted-publishing) (OIDC, no API tokens) and triggers automatically on tag push (`.github/workflows/crates-release.yml`).
+
 ## Requirements
 
 This guide requires:
@@ -22,10 +24,7 @@ This guide requires:
  * `cargo` (suggested: latest stable toolchain from [rustup][rustup])
  * `cargo-release` (suggested: `cargo install -f cargo-release`)
  * `cargo vendor-filterer` (suggested: `cargo install -f cargo-vendor-filterer`)
- * A verified account on crates.io
  * Write access to this GitHub project
- * Upload access to this project on GitHub, crates.io
- * Membership in the [Fedora CoreOS Crates Owners group](https://github.com/orgs/coreos/teams/fedora-coreos-crates-owners/members)
 
 ## Release checklist
 
@@ -54,15 +53,15 @@ This guide requires:
   - [ ] verify `Cargo.toml` has the expected version
   - [ ] `git-evtag sign v${RELEASE_VER}`
   - [ ] `git push --tags origin v${RELEASE_VER}`
-  - [ ] `cargo publish`
+  - [ ] **Automated:** `crates-release.yml` publishes to crates.io via trusted publishing
 
 - publish this release on GitHub:
   - [ ] find the new tag in the [GitHub tag list](https://github.com/coreos/bootupd/tags), click the triple dots menu, and create a release for it
   - [ ] write a short changelog with `git shortlog $last_tag..` (i.e. re-use the PR content). See previous releases for format, for example [`v0.2.25`](https://hackmd.io/@hhei/SkYe0AtMye)
-  - [ ] upload `target/${PROJECT}-${RELEASE_VER}-vendor.tar.gz`
+  - [ ] upload `target/${PROJECT}-${RELEASE_VER}-vendor.tar.zstd`
   - [ ] record digests of local artifacts:
     - `sha256sum target/package/${PROJECT}-${RELEASE_VER}.crate`
-    - `sha256sum target/${PROJECT}-${RELEASE_VER}-vendor.tar.gz`
+    - `sha256sum target/${PROJECT}-${RELEASE_VER}-vendor.tar.zstd`
   - [ ] publish release
 
 - clean up:

--- a/.github/workflows/crates-release.yml
+++ b/.github/workflows/crates-release.yml
@@ -1,0 +1,27 @@
+# See https://crates.io/docs/trusted-publishing
+name: Publish to crates.io
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch: {}
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write     # Required for OIDC token exchange
+    steps:
+    - uses: actions/checkout@v6
+    - uses: rust-lang/crates-io-auth-action@v1
+      id: auth
+    - run: |
+        # Publish if this version is not already on crates.io.
+        VERSION=$(cargo read-manifest | jq -r '.version')
+        if cargo info --registry crates-io "bootupd@$VERSION" > /dev/null 2>&1; then
+          echo "bootupd@$VERSION is already published, skipping"
+        else
+          echo "Publishing bootupd@$VERSION..."
+          cargo publish
+          echo "Successfully published bootupd@$VERSION"
+        fi
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ signal-hook-registry = "1.4.8"
 debug = true
 
 [package.metadata.release]
-disable-publish = true
 disable-push = true
 post-release-commit-message = "cargo: development version bump"
 pre-release-commit-message = "cargo: bootupd release {{version}}"


### PR DESCRIPTION
Adopt the same trusted-publishing approach used by bootc-dev/bootc so that cargo publish happens automatically when a v* tag is pushed, with no stored API tokens needed.

The new crates-release.yml workflow obtains an OIDC token via rust-lang/crates-io-auth-action and publishes idempotently (skips if the version is already on crates.io).

The release checklist is updated to note the automation, remove the now-unnecessary crates.io account requirements, and fix the vendor tarball extension (.tar.gz → .tar.zstd).

One-time setup: configure a trusted publisher on crates.io for the
bootupd crate (owner: coreos/bootupd, workflow: crates-release.yml).

Assisted-by: OpenCode (Claude Opus 4)