### PR TITLE
Disable systemd service on CoreOS live filesystems

### DIFF
--- a/systemd/bootloader-update.service
+++ b/systemd/bootloader-update.service
@@ -4,6 +4,9 @@ Documentation=https://github.com/coreos/bootupd
 
 [Service]
 Type=oneshot
+# It doesn't make sense to update bootloader in "Live" environments.
+# https://github.com/coreos/fedora-coreos-tracker/issues/2136
+ExecCondition=/bin/bash -c '[[ ! $(findmnt -n -o FSTYPE /sysroot) =~ ^(erofs|squashfs)$ ]]'
 ExecStart=/usr/bin/bootupctl update
 RemainAfterExit=yes
 # Keep this stuff in sync with SYSTEMD_ARGS_BOOTUPD in general


### PR DESCRIPTION
When running from live-iso `bootupctl` fails with:
```
    error: Querying adoptable state: creation time is not available for the filesystem
```
That happens because filesystem (erofs|squashfs) doesn't support statx.stx_btime field:
```
    $ stat /sysroot/.coreos-aleph-version.json
    Access: 2022-08-01 23:42:11.000000000 +0000
    Modify: 2022-08-01 23:42:11.000000000 +0000
    Change: 2022-08-01 23:42:11.000000000 +0000
     Birth: -
```
Issue: https://github.com/coreos/fedora-coreos-tracker/issues/2136