### PR TITLE
efi: Respect SOURCE_DATE_EPOCH for reproducible builds

### DIFF
--- a/src/efi.rs
+++ b/src/efi.rs
@@ -15,7 +15,6 @@ use camino::{Utf8Path, Utf8PathBuf};
 use cap_std::fs::Dir;
 use cap_std_ext::cap_std;
 use cap_std_ext::dirext::CapStdExtDirExt;
-use chrono::prelude::*;
 use fn_error_context::context;
 use openat_ext::OpenatDirExt;
 use os_release::OsRelease;
@@ -29,7 +28,7 @@ use crate::bootupd::RootContext;
 use crate::freezethaw::fsfreeze_thaw_cycle;
 use crate::model::*;
 use crate::ostreeutil;
-use crate::util;
+use crate::util::{self, get_metadata_timestamp};
 use crate::{component::*, packagesystem::*};
 use crate::{filetree, grubconfigs};
 
@@ -817,10 +816,8 @@ fn generate_meta_from_usr_efi(sysroot_path: &Utf8Path) -> Result<ContentMetadata
     }
     modules_vec.sort_unstable();
 
-    // change to now to workaround https://github.com/coreos/bootupd/issues/933
-    let timestamp = std::time::SystemTime::now();
     let meta = ContentMetadata {
-        timestamp: chrono::DateTime::<Utc>::from(timestamp),
+        timestamp: get_metadata_timestamp()?,
         version: packages.join(","),
         versions: Some(modules_vec),
     };

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,6 +3,8 @@ use std::path::Path;
 use std::process::Command;
 
 use anyhow::{bail, Context, Result};
+use chrono::{DateTime, Utc};
+use fn_error_context::context;
 use openat_ext::OpenatDirExt;
 
 /// Parse an environment variable as UTF-8
@@ -120,4 +122,26 @@ impl Drop for SignalTerminationGuard {
     fn drop(&mut self) {
         signal_hook_registry::unregister(self.0);
     }
+}
+
+#[context("Getting timestamp for metadata")]
+pub fn get_metadata_timestamp() -> Result<DateTime<Utc>> {
+    let ts = match std::env::var("SOURCE_DATE_EPOCH") {
+        Ok(value) => {
+            let unix_secs = value
+                .parse::<i64>()
+                .context("Parsing SOURCE_DATE_EPOCH as integer")?;
+
+            chrono::DateTime::from_timestamp_secs(unix_secs).ok_or_else(|| {
+                anyhow::anyhow!("SOURCE_DATE_EPOCH value '{value}' is not a valid timestamp")
+            })?
+        }
+        Err(std::env::VarError::NotPresent) => {
+            let timestamp = std::time::SystemTime::now();
+            chrono::DateTime::<Utc>::from(timestamp)
+        }
+        Err(e) => Err(e).context("Reading SOURCE_DATE_EPOCH")?,
+    };
+
+    Ok(ts)
 }


### PR DESCRIPTION
If SOURCE_DATE_EPOCH env is set, use it for EFI metadata timestamp, else fallback to SystemTime::now()

The BIOS component derives its timestamp from RPM build times so it is already deterministic

Fixes: https://github.com/coreos/bootupd/issues/1075