### PR TITLE
Only do "booted BIOS with no update" check during actual update

### DIFF
--- a/src/bios.rs
+++ b/src/bios.rs
@@ -244,12 +244,15 @@ impl Component for Bios {
     }
 
     fn query_update(&self, sysroot: &openat::Dir) -> Result<Option<ContentMetadata>> {
-        let content_metadata = get_component_update(sysroot, self)?;
+        get_component_update(sysroot, self)
+    }
+
+    fn query_requires_update(&self, sysroot: &openat::Dir) -> Result<()> {
         // Failed as expected if booted with BIOS and no update metadata
-        if content_metadata.is_none() && !sysroot.exists("sys/firmware/efi")? {
+        if !sysroot.exists("sys/firmware/efi")? {
             anyhow::bail!("Failed to find BIOS update metadata");
         }
-        Ok(content_metadata)
+        Ok(())
     }
 
     fn run_update(&self, rootcxt: &RootContext, _: &InstalledContent) -> Result<InstalledContent> {

--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -323,7 +323,10 @@ pub(crate) fn update(name: &str, rootcxt: &RootContext) -> Result<ComponentUpdat
             std::cmp::Ordering::Less => p, // current < available -> upgrade
             _ => return Ok(ComponentUpdateResult::AtLatestVersion),
         },
-        None => return Ok(ComponentUpdateResult::AtLatestVersion),
+        None => {
+            component.query_requires_update(sysroot)?;
+            return Ok(ComponentUpdateResult::AtLatestVersion);
+        }
     };
 
     ensure_writable_boot()?;

--- a/src/component.rs
+++ b/src/component.rs
@@ -73,6 +73,11 @@ pub(crate) trait Component {
     /// Used on the client to query for an update cached in the current booted OS.
     fn query_update(&self, sysroot: &openat::Dir) -> Result<Option<ContentMetadata>>;
 
+    /// This is called in the update code if query_update() returned no metadata.
+    /// It should return an error if the current booted system should expect some
+    /// metadata for this component.
+    fn query_requires_update(&self, sysroot: &openat::Dir) -> Result<()>;
+
     /// Used on the client to run an update.
     fn run_update(
         &self,

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -613,12 +613,15 @@ impl Component for Efi {
     }
 
     fn query_update(&self, sysroot: &openat::Dir) -> Result<Option<ContentMetadata>> {
-        let content_metadata = get_component_update(sysroot, self)?;
+        get_component_update(sysroot, self)
+    }
+
+    fn query_requires_update(&self, _sysroot: &openat::Dir) -> Result<()> {
         // Failed as expected if booted with EFI and no update metadata
-        if content_metadata.is_none() && is_efi_booted()? {
+        if is_efi_booted()? {
             anyhow::bail!("Failed to find EFI update metadata");
         }
-        Ok(content_metadata)
+        Ok(())
     }
 
     fn validate(&self, current: &InstalledContent, device: &Device) -> Result<ValidationResult> {


### PR DESCRIPTION
This fixes https://github.com/coreos/bootupd/issues/1035 which introduced this check, but did so in every query_update(). However, that is called from non-update places too. In particular from install(), which causes bootc-image-builder to break if used on non-EFI systems.

Instead we break out the check to a separate component function query_requires_update() which is only called in the update-with-missing-component case.