### PR TITLE
status: align JSON and default output

### DIFF
--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -588,6 +588,19 @@ pub(crate) fn status() -> Result<Status> {
     let mut known_components = get_components();
     let root = Dir::open_ambient_dir("/", ambient_authority())?;
 
+    // Populate aleph version
+    ret.aleph_version = aleph::get_aleph_version(Path::new("/"))?.map(|a| a.aleph.version);
+
+    // Populate boot method
+    #[cfg(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64"
+    ))]
+    {
+        ret.boot_method = Some(if efi::is_efi_booted()? { "EFI" } else { "BIOS" }.into());
+    }
+
     let bootloader = get_bootloader()?;
     let state = SavedState::load_from_disk("/", Some(bootloader))?;
 
@@ -706,17 +719,11 @@ pub(crate) fn print_status(status: &Status) -> Result<()> {
         }
     }
 
-    if let Some(aleph) = aleph::get_aleph_version(Path::new("/"))? {
-        println!("Aleph version: {}", aleph.aleph.version);
+    if let Some(aleph_version) = &status.aleph_version {
+        println!("Aleph version: {}", aleph_version);
     }
 
-    #[cfg(any(
-        target_arch = "x86_64",
-        target_arch = "aarch64",
-        target_arch = "riscv64"
-    ))]
-    {
-        let boot_method = if efi::is_efi_booted()? { "EFI" } else { "BIOS" };
+    if let Some(boot_method) = &status.boot_method {
         println!("Boot method: {}", boot_method);
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -168,6 +168,10 @@ pub(crate) struct Adoptable {
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Status {
+    /// Origin version from the Aleph file
+    pub(crate) aleph_version: Option<String>,
+    /// The method used to boot the system (e.g. "EFI" or "BIOS"), if detected
+    pub(crate) boot_method: Option<String>,
     /// Maps a component name to status
     pub(crate) components: BTreeMap<String, ComponentStatus>,
     /// Components that appear to be installed, not via bootupd
@@ -275,6 +279,8 @@ mod test {
     fn test_deserialize_status() -> Result<()> {
         let data = include_str!("../tests/fixtures/example-status-v0.json");
         let status: Status = serde_json::from_str(data)?;
+        assert_eq!(status.aleph_version.as_deref(), Some("32.20201002.dev.2"));
+        assert_eq!(status.boot_method.as_deref(), Some("EFI"));
         let efi = status.components.get("EFI").expect("EFI");
         assert_eq!(
             efi.installed.version,

--- a/tests/fixtures/example-status-v0.json
+++ b/tests/fixtures/example-status-v0.json
@@ -1,4 +1,6 @@
 {
+  "aleph-version": "32.20201002.dev.2",
+  "boot-method": "EFI",
   "components": {
     "EFI": {
       "installed": {


### PR DESCRIPTION
Add `aleph-version` and `boot-method` to the `Status` struct so both `--json` and regular output are showing consistent content.