### PR TITLE
ci: fix cross job failures on s390x and ppc64le

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -35,7 +35,7 @@ jobs:
           run: |
             set -xeu
             apt update -y
-            apt install -y gcc make curl libssl-dev pkg-config
+            apt install -y build-essential curl libssl-dev pkg-config
             # Install Rust 1.90.0
             curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.90.0
             source $HOME/.cargo/env


### PR DESCRIPTION
Install build-essential in this job to ensure we get libc6-dev, which is what's needed to avoid the linking errors in the most recent CI runs.