### PR TITLE
tests/test-bootupd: fix stale 'CoreOS aleph version' assertion

### DIFF
--- a/tests/kola/test-bootupd
+++ b/tests/kola/test-bootupd
@@ -91,7 +91,7 @@ else
     assert_file_has_content_literal out.txt '  Installed: grub2-efi-x64-'
 fi
 assert_file_has_content_literal out.txt 'Update: At latest version'
-assert_file_has_content out.txt '^CoreOS aleph version:'
+assert_file_has_content out.txt '^Aleph version:'
 ok status
 
 bootupctl validate | tee out.txt


### PR DESCRIPTION
Commit e7a2e0af generalized the aleph handling to also support bootc installs, and renamed the printed status line from 'CoreOS aleph version:' to 'Aleph version:' since the field is no longer CoreOS-specific. The kola test wasn't updated to match, so 'bootupctl status' kola runs (and downstream fedora-coreos-config tests) started failing on the stale grep.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>