### PR TITLE
build(deps): drop some trivially replaceable dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,6 @@ dependencies = [
  "tempfile",
  "uapi-version",
  "walkdir",
- "widestring",
 ]
 
 [[package]]
@@ -1544,12 +1543,6 @@ dependencies = [
  "indexmap",
  "semver",
 ]
-
-[[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,6 @@ dependencies = [
  "env_logger",
  "fail",
  "fn-error-context",
- "fs2",
  "libc",
  "libsystemd",
  "log",
@@ -495,16 +494,6 @@ dependencies = [
  "io-lifetimes 2.0.4",
  "rustix",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -1545,22 +1534,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,12 +1541,6 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,6 @@ dependencies = [
  "fail",
  "fn-error-context",
  "fs2",
- "hex",
  "libc",
  "libsystemd",
  "log",
@@ -576,12 +575,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,6 @@ dependencies = [
  "log",
  "openssl",
  "os-release",
- "regex",
  "rpm-version",
  "rustix",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ clap = { version = "4.6", default-features = false, features = ["cargo", "derive
 env_logger = "0.11"
 fail = { version = "0.5", features = ["failpoints"] }
 fn-error-context = "0.2.1"
-fs2 = "0.4.3"
 libc = "^0.2"
 libsystemd = ">= 0.3, < 0.8"
 log = "^0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 tempfile = "^3.26"
 uapi-version = "0.4.0"
-widestring = "1.2.1"
 walkdir = "2.3.2"
 signal-hook-registry = "1.4.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ log = "^0.4"
 cap-std = "4.0.2"
 openssl = "^0.10"
 os-release = "0.1.0"
-regex = "1.12.3"
 rpm-version = { version = "0.5.0", default-features = false, optional = true }
 rustix = { version = "1.1.4", features = ["process", "fs"] }
 serde = { version = "^1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ env_logger = "0.11"
 fail = { version = "0.5", features = ["failpoints"] }
 fn-error-context = "0.2.1"
 fs2 = "0.4.3"
-hex = "0.4.3"
 libc = "^0.2"
 libsystemd = ">= 0.3, < 0.8"
 log = "^0.4"

--- a/src/backend/statefile.rs
+++ b/src/backend/statefile.rs
@@ -12,7 +12,7 @@ use cap_std::ambient_authority;
 use cap_std::fs::{Dir, Permissions, PermissionsExt};
 use cap_std_ext::dirext::CapStdExtDirExt;
 use fn_error_context::context;
-use fs2::FileExt;
+use rustix::fs::{flock, FlockOperation};
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
@@ -90,7 +90,7 @@ impl SavedState {
             .context("Opening lock file")?
             .into_std();
 
-        lockfile.lock_exclusive().context("Acquiring lock")?;
+        flock(&lockfile, FlockOperation::LockExclusive).context("Acquiring lock")?;
 
         let guard = StateLockGuard {
             sysroot_path,

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -23,7 +23,6 @@ use rustix::mount::MountFlags;
 use rustix::path::Arg;
 use rustix::{fd::AsFd, fd::BorrowedFd, fs::StatVfsMountFlags};
 use walkdir::WalkDir;
-use widestring::U16CString;
 
 use bootc_internal_blockdev::Device;
 
@@ -285,7 +284,8 @@ fn string_from_utf16_bytes(slice: &[u8]) -> String {
     let v: Vec<u16> = (0..size)
         .map(|i| u16::from_ne_bytes([slice[2 * i], slice[2 * i + 1]]))
         .collect();
-    U16CString::from_vec(v).unwrap().to_string_lossy()
+    let end = v.iter().position(|&c| c == 0).unwrap_or(v.len());
+    String::from_utf16_lossy(&v[..end])
 }
 
 /// Read a nul-terminated UTF-16 string from an EFI variable.
@@ -1254,5 +1254,23 @@ Boot0003* test";
         );
         assert_eq!("no_change", &get_system_name("no_change"));
         assert_eq!("", &get_system_name(""));
+    }
+
+    #[test]
+    fn test_string_from_utf16_bytes() {
+        assert_eq!(
+            "hello",
+            string_from_utf16_bytes(&[b'h', 0, b'e', 0, b'l', 0, b'l', 0, b'o', 0]),
+        );
+        assert_eq!(
+            "nul",
+            string_from_utf16_bytes(&[b'n', 0, b'u', 0, b'l', 0, 0, 0, b'l', b'0']),
+        );
+        assert_eq!(
+            "SYS",
+            string_from_utf16_bytes(&[b'S', 0, b'Y', 0, b'S', 0, 0, 0, 0,]),
+        );
+        assert_eq!("", string_from_utf16_bytes(&[]));
+        assert_eq!("", string_from_utf16_bytes(&[0, 0]));
     }
 }

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -256,14 +256,21 @@ impl Efi {
     }
 }
 
+/// Helper function to remove ".release.*" from the contents of etc/system-release, leaving just the name
+fn get_system_name(contents: impl AsRef<str>) -> String {
+    let contents = contents.as_ref();
+    match contents.find("release") {
+        Some(index) => contents[..index].trim().to_owned(),
+        None => contents.trim().to_owned(),
+    }
+}
+
 #[context("Get product name")]
 fn get_product_name(sysroot: &Dir) -> Result<String> {
     let release_path = "etc/system-release";
     if sysroot.exists(release_path) {
-        let content = sysroot.read_to_string(release_path)?;
-        let re = regex::Regex::new(r" *release.*").unwrap();
-        let name = re.replace_all(&content, "").trim().to_string();
-        return Ok(name);
+        let contents = sysroot.read_to_string(release_path)?;
+        return Ok(get_system_name(contents));
     }
     // Read /etc/os-release
     let release: OsRelease = OsRelease::new()?;
@@ -1235,5 +1242,17 @@ Boot0003* test";
         let efi_comps = get_efi_component_from_usr(utf8_tpath, EFILIB, None)?;
         assert_eq!(efi_comps, None);
         Ok(())
+    }
+
+    #[test]
+    fn test_get_system_name() {
+        assert_eq!("Fedora", &get_system_name("Fedora release 44 (Forty Four)"));
+        assert_eq!("CentOS Stream", &get_system_name("CentOS Stream release 9"));
+        assert_eq!(
+            "Red Hat Enterprise Linux",
+            &get_system_name("Red Hat Enterprise Linux release 10.2 (Coughlan)")
+        );
+        assert_eq!("no_change", &get_system_name("no_change"));
+        assert_eq!("", &get_system_name(""));
     }
 }

--- a/src/sha512string.rs
+++ b/src/sha512string.rs
@@ -8,6 +8,16 @@ use openssl::hash::Hasher;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+/// Helper function for converting a `[&[u8]]` into a hex string.
+fn bytes_to_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        write!(s, "{b:02x}").expect("should not fail writing to a string");
+    }
+    s
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, Ord, PartialOrd, PartialEq, Eq)]
 pub(crate) struct SHA512String(pub(crate) String);
 
@@ -22,7 +32,7 @@ impl SHA512String {
     pub(crate) fn from_hasher(hasher: &mut Hasher) -> Self {
         Self(format!(
             "sha512:{}",
-            hex::encode(hasher.finish().expect("completing hash"))
+            bytes_to_hex(&hasher.finish().expect("completing hash"))
         ))
     }
 }
@@ -38,5 +48,13 @@ mod test {
         let s = SHA512String::from_hasher(&mut h);
         assert_eq!("sha512:cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e", format!("{}", s));
         Ok(())
+    }
+
+    #[test]
+    fn test_bytes_to_hex() {
+        assert_eq!(bytes_to_hex(&[0xde, 0xad, 0xbe, 0xef]), "deadbeef");
+        assert_eq!(bytes_to_hex(&[0x00, 0x0a, 0xff]), "000aff");
+        assert_eq!(bytes_to_hex(&[]), "");
+        assert_eq!(bytes_to_hex(&[0x42]), "42");
     }
 }


### PR DESCRIPTION
See individual commits. We can discuss individual dependencies but as it stands this PR would drop:

- [hex](https://docs.rs/hex/latest/hex/)
- [regex](https://docs.rs/regex/latest/regex/) (from direct dependency only)
- [widestring](https://docs.rs/widestring/latest/widestring/)
- [fs2](https://docs.rs/fs2/latest/fs2/)