### PR TITLE
secureboot: add check to validate signature db certificates before updating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -73,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -87,6 +87,17 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitfield-struct"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca6739863c590881f038d033a146c51ddae239186a4327014839fd864f44ed5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "bitflags"
@@ -192,6 +203,7 @@ dependencies = [
  "signal-hook-registry",
  "tempfile",
  "uapi-version",
+ "virtfw-libefi",
  "walkdir",
 ]
 
@@ -200,6 +212,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -230,7 +248,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
  "winx",
 ]
 
@@ -271,7 +289,7 @@ dependencies = [
  "rustix",
  "rustix-linux-procfs",
  "uuid",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -326,9 +344,11 @@ version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -427,7 +447,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -805,7 +825,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1061,7 +1081,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1230,7 +1250,17 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1373,6 +1403,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "849f6b1fe8a0fb07170737d7f3acf72cac5462fb3f4e86614474a49f7fac3b65"
 
 [[package]]
+name = "uguid"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8352f8c05e47892e7eaf13b34abd76a7f4aeaf817b716e88789381927f199c"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,6 +1455,22 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtfw-libefi"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8508c830cd7bd67ed6103ddc02a04b7aabfe6d2d57b1a1767ff8ec20b706a39"
+dependencies = [
+ "bitfield-struct",
+ "byteorder",
+ "chrono",
+ "clap",
+ "libc",
+ "log",
+ "uguid",
+ "zerocopy",
+]
 
 [[package]]
 name = "walkdir"
@@ -1539,7 +1591,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,10 @@ uapi-version = "0.4.0"
 walkdir = "2.3.2"
 signal-hook-registry = "1.4.8"
 
+# EFI-only dependencies
+[target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64"))'.dependencies]
+virtfw-libefi = { version = "0.6", features = ["std", "sbdata"] }
+
 [profile.release]
 # We assume we're being delivered via e.g. RPM which supports split debuginfo
 debug = true

--- a/src/cli/bootupctl.rs
+++ b/src/cli/bootupctl.rs
@@ -1,4 +1,6 @@
 use crate::bootupd;
+#[cfg(efi_arch)]
+use crate::secureboot::validate_secureboot_for_update;
 use anyhow::Result;
 use clap::Parser;
 use log::LevelFilter;
@@ -54,7 +56,7 @@ pub enum CtlVerb {
     #[clap(name = "status", about = "Show components status")]
     Status(StatusOpts),
     #[clap(name = "update", about = "Update all components")]
-    Update,
+    Update(UpdateOpts),
     #[clap(name = "adopt-and-update", about = "Update all adoptable components")]
     AdoptAndUpdate(AdoptAndUpdateOpts),
     #[clap(name = "validate", about = "Validate system state")]
@@ -92,10 +94,25 @@ pub struct StatusOpts {
 }
 
 #[derive(Debug, Parser)]
+pub struct UpdateOpts {
+    /// Whether to skip the check for the Microsoft 2023 CA UEFI certificate
+    /// when updating if Secure Boot is enabled.
+    ///
+    /// This is a safety feature intended to prevent users from breaking
+    /// Secure Boot. Therefore, it's recommended to only use this flag
+    /// if you know what you're doing.
+    #[cfg(efi_arch)]
+    #[clap(long, action)]
+    skip_ms_2023_cert_check: bool,
+}
+
+#[derive(Debug, Parser)]
 pub struct AdoptAndUpdateOpts {
     /// Install the static GRUB config files
     #[clap(long, action)]
     with_static_config: bool,
+    #[command(flatten)]
+    update: UpdateOpts,
 }
 
 impl CtlCommand {
@@ -103,7 +120,7 @@ impl CtlCommand {
     pub fn run(self) -> Result<()> {
         match self.cmd {
             CtlVerb::Status(opts) => Self::run_status(opts),
-            CtlVerb::Update => Self::run_update(),
+            CtlVerb::Update(opts) => Self::run_update(opts),
             CtlVerb::AdoptAndUpdate(opts) => Self::run_adopt_and_update(opts),
             CtlVerb::Validate => Self::run_validate(),
             CtlVerb::Backend(CtlBackend::Generate(opts)) => {
@@ -141,14 +158,22 @@ impl CtlCommand {
     }
 
     /// Runner for `update` verb.
-    fn run_update() -> Result<()> {
+    fn run_update(_opts: UpdateOpts) -> Result<()> {
         ensure_running_in_systemd()?;
+        #[cfg(efi_arch)]
+        if !_opts.skip_ms_2023_cert_check {
+            validate_secureboot_for_update()?;
+        }
         bootupd::client_run_update()
     }
 
-    /// Runner for `update` verb.
+    /// Runner for `adopt-and-update` verb.
     fn run_adopt_and_update(opts: AdoptAndUpdateOpts) -> Result<()> {
         ensure_running_in_systemd()?;
+        #[cfg(efi_arch)]
+        if !opts.update.skip_ms_2023_cert_check {
+            validate_secureboot_for_update()?;
+        }
         bootupd::client_run_adopt_and_update(opts.with_static_config)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,8 @@ mod model;
 mod model_legacy;
 mod ostreeutil;
 mod packagesystem;
+#[cfg(efi_arch)]
+mod secureboot;
 mod sha512string;
 mod util;
 

--- a/src/secureboot.rs
+++ b/src/secureboot.rs
@@ -1,0 +1,75 @@
+//! Module with checks related to Secure Boot.
+//!
+//! This is primarily used for checking whether it is safe to update a system which has Secure
+//! Boot enabled. There can be complications if updating to a new version of shim which is only
+//! signed by Microsoft keys which the user's system does not have matching certificates for,
+//! so in that scenario we just block updates until the firmware is updated to match (most likely by
+//! fwupd).
+//!
+//! See https://github.com/coreos/bootupd/issues/1099
+
+use anyhow::{bail, Result};
+use fn_error_context::context;
+use log::info;
+use virtfw_libefi::efivar::{ids, sigdb::EfiSigDB};
+use virtfw_libefi::sb::certs;
+use virtfw_libefi::varstore::sysfs;
+
+/// Check whether Secure Boot is enabled.
+fn is_secureboot_enabled() -> bool {
+    let Some(var) = sysfs::varstore_read(ids::SECURE_BOOT.name, ids::SECURE_BOOT.guid) else {
+        info!("Could not read the Secure Boot EFI variable. Assuming Secure Boot is not enabled.");
+        return false;
+    };
+    // First byte represents a boolean for "is_enabled"
+    match var.data().first() {
+        Some(&b) => b != 0,
+        None => false,
+    }
+}
+
+/// Check whether the firmware's signature database contains the Microsoft UEFI CA 2023 certificate.
+fn db_contains_ms_2023_cert() -> Result<bool> {
+    let Some(var) = sysfs::varstore_read(ids::DB.name, ids::DB.guid) else {
+        // At this stage, we'll have confirmed the user does have Secure Boot enabled.
+        // Best to be safe and abort any updates if we can't even read the EFI variable.
+        bail!("Could not read the signature database variable. Assuming it is not safe to update.");
+    };
+    let Some(sigdb) = EfiSigDB::new_from_bytes(var.data()) else {
+        bail!("Failed to parse Secure Boot signature database (unknown layout). Assuming it is not safe to update.");
+    };
+
+    Ok(sigdb
+        .get_x509_list()
+        .contains(&certs::MICROSOFT_DB_UEFI_2023))
+}
+
+/// Attempt to validate that the system can safely accept an EFI bootloader update (if EFI-booted).
+///
+/// If Secure Boot is enabled, we can't allow updates if the signature database doesn't contain
+/// the Microsoft UEFI CA 2023 certificate.
+#[context("Validating Secure Boot certificate compatibility")]
+pub(crate) fn validate_secureboot_for_update() -> Result<()> {
+    if !crate::efi::is_efi_booted()? {
+        info!("Not EFI-booted, skipping Secure Boot certificate check");
+        return Ok(());
+    }
+
+    if !is_secureboot_enabled() {
+        info!("Secure Boot not enabled, skipping Secure Boot certificate check");
+        return Ok(());
+    };
+
+    match db_contains_ms_2023_cert() {
+        Ok(true) => {
+            info!("Secure Boot DB contains Microsoft UEFI CA 2023 certificate. Safe to update.");
+            Ok(())
+        }
+        Ok(false) => bail!(
+            "Secure Boot is enabled but the Microsoft UEFI CA 2023 certificate was not \
+             found in the firmware's signature database. Updating the shim could render this system \
+             unbootable. Please update your system firmware by using, for example, fwupd."
+        ),
+        Err(e) => Err(e),
+    }
+}

--- a/tests/kola/test-secureboot
+++ b/tests/kola/test-secureboot
@@ -1,0 +1,32 @@
+#!/bin/bash
+## kola:
+##   # qemu is the only platform where setting a 'secure-boot' tag will cause
+##   # secureboot to get turned on for that instance.
+##   platforms: qemu
+##   # Mark as exclusive since we are requesting secureboot and that won't take effect when we're
+##   # running non-exclusively.
+##   exclusive: true
+##   tags: secure-boot
+##   architectures: x86_64
+##   description: Verify that Secure Boot certificate validation works as intended
+#
+# See https://github.com/coreos/bootupd/issues/1099
+#
+# NOTE: we're only testing the positive case here, as testing the negative case
+# is non-trivial since we need to generate and use a custom vars file with only the 2011 cert.
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/libtest.sh
+
+if [[ "$(mokutil --sb)" != "SecureBoot enabled" ]]; then
+    fatal "system is not running with Secure Boot enabled"
+fi
+
+bootupctl status > /tmp/out.txt
+assert_file_has_content_literal /tmp/out.txt 'Component EFI'
+
+# No need to force an update scenario since this should hit the certificate check
+# regardless of whether there's any available updates.
+bootupctl update
+ok "passed the Secure Boot certificate check when the 2023 Microsoft cert is available"


### PR DESCRIPTION
Closes https://github.com/coreos/bootupd/issues/1099

The main concern this resolves is that, with the Microsoft UEFI CA 2011 Certificate having expired, any further updates to the shim will not be dual-signed, and will only be signed by the 2023 key. This means that any system with Secure Boot enabled will be broken if `bootupd` updates the shim and the system does not have the certificate available in their firmware's signature database. So we should make sure `bootupd` is aware of this requirement so we don't break user's Secure Boot systems.

As stated in the issue, we wanted a way to incorporate some of the `sbchooser` logic to achieve this goal. However, I found [this crate](https://crates.io/crates/virtfw-libefi) which suits our use-case perfectly. I discussed briefly with the creator and he agreed it was a good fit.

I've implemented this in such a way that any update will be blocked if Secure Boot is enabled and the 2023 cert is not in the system's signature DB. So updating is allowed as long as any one of the following is true:

1. System is not EFI-booted
2. System does not have Secure Boot enabled
3. System has the 2023 cert in the signature database

Something that might be nice but would add some complexity is only blocking updates if the shim is actually being updated, as that's the only one that matters here. Any thoughts on this? I think it's gonna be a brief enough window where this is actually helpful that keeping it as simple as possible will benefit us more in the long run. Plus Secure Boot systems with outdated certificates should indeed have their firmware updated as soon as possible. I'd be happy to try implement the module comparison logic if we think it's important to only block on shim updates though.

Also for  testing, I have a positive case test, and tested the negative case manually. I can't think of a good way to test the negative case with kola. Maybe including a feature in kola to enable using the db with an older certificate (binary blob?), but I'm not sure that's worth it.