### PR TITLE
Release 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "bootupd"
-version = "0.2.36"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bootc-internal-blockdev",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bootupd"
 description = "Bootloader updater"
 license = "Apache-2.0"
-version = "0.2.36"
+version = "0.3.0"
 authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2021"
 rust-version = "1.90.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 rust-version = "1.90.0"
 homepage = "https://github.com/coreos/bootupd"
 
-include = ["src", "LICENSE", "Makefile", "systemd"]
+include = ["src", "LICENSE", "Makefile", "systemd", "build.rs"]
 
 # See https://github.com/coreos/cargo-vendor-filterer
 [package.metadata.vendor-filter]

--- a/contrib/packaging/bootupd.spec
+++ b/contrib/packaging/bootupd.spec
@@ -3,7 +3,7 @@
 %global crate bootupd
 
 Name:           rust-%{crate}
-Version:        0.2.36
+Version:        0.3.0
 Release:        1%{?dist}
 Summary:        Bootloader updater
 

--- a/tests/e2e-update/e2e-update.sh
+++ b/tests/e2e-update/e2e-update.sh
@@ -93,6 +93,7 @@ systemd:
       enabled: true
       contents: |
         [Unit]
+        Before=bootloader-update.service
         RequiresMountsFor=/run/testtmp
         [Service]
         Type=oneshot


### PR DESCRIPTION
cargo.toml: Include build.rs

We have an important cfg macro in build.rs which was not being included
in the final crate

---

Release 0.3.0

We've had a lot of changes and I think it makes sense to have a minor
version update instead of updating patch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the crate and RPM package to version 0.3.0.
  * Included build configuration files in the packaged release.

* **Tests**
  * Improved end-to-end test ordering to run before bootloader updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->