### PR TITLE
install: Create `bootupctl` as symlink instead of hardlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,13 +21,13 @@ endif
 .PHONY: all
 all:
 	cargo build ${CARGO_ARGS}
-	ln -f target/${PROFILE}/bootupd target/${PROFILE}/bootupctl
+	ln -srf target/${PROFILE}/bootupd target/${PROFILE}/bootupctl
 
 .PHONY: install
 install:
 	mkdir -p "${DESTDIR}$(PREFIX)/bin" "${DESTDIR}$(LIBEXECDIR)"
 	install -D -t "${DESTDIR}$(LIBEXECDIR)" target/${PROFILE}/bootupd
-	ln -f ${DESTDIR}$(LIBEXECDIR)/bootupd ${DESTDIR}$(PREFIX)/bin/bootupctl
+	ln -srf ${DESTDIR}$(LIBEXECDIR)/bootupd ${DESTDIR}$(PREFIX)/bin/bootupctl
 
 .PHONY: install-grub-static
 install-grub-static:


### PR DESCRIPTION
rpmlint fails with bootupd.x86_64:
E: hardlink-across-partition /usr/libexec/bootupd /usr/bin/bootupctl

To resolve, create a symlink

Ref: https://src.fedoraproject.org/rpms/rust-bootupd/pull-request/28#