### PR TITLE
statefile: use stable inode for write lock

### DIFF
--- a/src/backend/statefile.rs
+++ b/src/backend/statefile.rs
@@ -9,7 +9,7 @@ use anyhow::{bail, Context, Result};
 use bootc_internal_blockdev::Device;
 use camino::Utf8PathBuf;
 use cap_std::ambient_authority;
-use cap_std::fs::{Dir, Permissions, PermissionsExt};
+use cap_std::fs::{Dir, OpenOptions, OpenOptionsExt, Permissions, PermissionsExt};
 use cap_std_ext::dirext::CapStdExtDirExt;
 use fn_error_context::context;
 use rustix::fs::{flock, FlockOperation};
@@ -81,13 +81,14 @@ impl SavedState {
         sysroot_path: Utf8PathBuf,
         sysroot: Dir,
     ) -> Result<StateLockGuard> {
-        sysroot
-            .atomic_write_with_perms(Self::WRITE_LOCK_PATH, "", Permissions::from_mode(0o644))
-            .context("Creating lock file")?;
-
+        let opts = {
+            let mut o = OpenOptions::new();
+            o.write(true).create(true).mode(0o644);
+            o
+        };
         let lockfile = sysroot
-            .open(Self::WRITE_LOCK_PATH)
-            .context("Opening lock file")?
+            .open_with(Self::WRITE_LOCK_PATH, &opts)
+            .context("Creating/opening lock file")?
             .into_std();
 
         flock(&lockfile, FlockOperation::LockExclusive).context("Acquiring lock")?;


### PR DESCRIPTION
The previous implementation used atomic_write_with_perms to create the lockfile, which replaces the file via rename on every call. This meant that concurrent callers could flock different inodes, defeating the purpose of the lock.

Let's replace that with OpenOptions create-or-open, which only creates the file if it doesn't already exist and opens the existing one otherwise, ensuring all callers lock the same inode. The lack of atomic writing here should not be an issue as the file has no content anyway.

Originally pointed out by the bot on https://github.com/coreos/bootupd/pull/1138, see https://github.com/coreos/bootupd/pull/1138#issuecomment-5479650954