### PR TITLE
BIOS Fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,35 @@ jobs:
     runs-on: [ "${{ matrix.runner }}" ]
 
     steps:
+      - name: Install QEMU and OVMF for VM boot tests
+        if: ${{ matrix.runner == 'ubuntu-24.04' }}
+        shell: bash
+        run: |
+          set -xeuo pipefail
+          sudo apt install -y qemu-utils qemu-kvm ovmf
+
+      - name: Enable unprivileged /dev/kvm access
+        if: ${{ matrix.runner == 'ubuntu-24.04' }}
+        shell: bash
+        run: |
+          set -xeuo pipefail
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+          ls -l /dev/kvm
+
+      - name: Configure Podman
+        shell: bash
+        run: |
+          podman --version
+          mkdir -p ~/.config/containers
+          echo '{"defaultAction":"SCMP_ACT_ALLOW"}' > ~/.config/containers/seccomp.json
+          printf '[containers]\napparmor_profile = "unconfined"\nseccomp_profile = "%s/.config/containers/seccomp.json"\n' "$HOME" > ~/.config/containers/containers.conf
+          USER_NAME=$(id -un)
+          grep -q "^${USER_NAME}:" /etc/subuid || echo "${USER_NAME}:100000:65536" | sudo tee -a /etc/subuid
+          grep -q "^${USER_NAME}:" /etc/subgid || echo "${USER_NAME}:100000:65536" | sudo tee -a /etc/subgid
+          podman info --format '{{.Store.GraphRoot}}'
+
       - name: Setup env
         run: |
           IMG_NAME=localhost/bootupd-grubcc-${{ matrix.grubcc }}
@@ -153,3 +182,16 @@ jobs:
           set -xeuo pipefail
           sudo ./scripts/test-bootloader.sh "$IMG_NAME" "grub-cc"
           sudo ./scripts/test-bootloader.sh "$IMG_NAME" "systemd"
+
+      - name: Test BIOS installs and VM boot
+        if: ${{ matrix.runner == 'ubuntu-24.04' }}
+        run: |
+          set -xeuo pipefail
+          sudo ./scripts/test-bios-vm-boot.sh "$IMG_NAME"
+
+      - name: Test UEFI installs and VM boot
+        if: ${{ matrix.runner == 'ubuntu-24.04' }}
+        run: |
+          set -xeuo pipefail
+          sudo ./scripts/test-uefi-vm-boot.sh "$IMG_NAME" "ostree"
+          sudo ./scripts/test-uefi-vm-boot.sh "$IMG_NAME" "composefs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,18 +48,6 @@ jobs:
           sudo udevadm trigger --name-match=kvm
           ls -l /dev/kvm
 
-      - name: Configure Podman
-        shell: bash
-        run: |
-          podman --version
-          mkdir -p ~/.config/containers
-          echo '{"defaultAction":"SCMP_ACT_ALLOW"}' > ~/.config/containers/seccomp.json
-          printf '[containers]\napparmor_profile = "unconfined"\nseccomp_profile = "%s/.config/containers/seccomp.json"\n' "$HOME" > ~/.config/containers/containers.conf
-          USER_NAME=$(id -un)
-          grep -q "^${USER_NAME}:" /etc/subuid || echo "${USER_NAME}:100000:65536" | sudo tee -a /etc/subuid
-          grep -q "^${USER_NAME}:" /etc/subgid || echo "${USER_NAME}:100000:65536" | sudo tee -a /etc/subgid
-          podman info --format '{{.Store.GraphRoot}}'
-
       - name: Setup env
         run: |
           IMG_NAME=localhost/bootupd-grubcc-${{ matrix.grubcc }}

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,1 @@
+sfdisk-buf

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -38,3 +38,22 @@ EOF
     mount "${loopdev}p2" /var/mnt/boot
 }
 
+run_bootupctl_bios() {
+    set +eu
+
+    IMG_NAME=$1
+
+    DEVICE=$(losetup -j /var/test-img.img | cut -d: -f1)
+
+    # Skip IMG_NAME
+    local bootloader=("${@:2}")
+
+    podman run --rm --net=host --privileged --pid=host \
+      --privileged \
+      --security-opt label=type:unconfined_t \
+      --env RUST_LOG=trace \
+      -v /dev:/dev \
+      -v /var/mnt:/var/mnt \
+      "$IMG_NAME" \
+      bootupctl backend install "${bootloader[@]}" --write-uuid --device "$DEVICE" --component BIOS /var/mnt -vvvv
+}

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+create_mount_device_bios() {
+    set +e
+
+    umount -R /var/mnt
+    losetup -j /var/test-img.img | cut -d: -f1 | xargs -r losetup -d
+
+    set -e
+
+    rm -rfv test-img.img
+
+    cat <<-EOF > sfdisk-buf
+label: gpt
+label-id:  65be9332-59ba-11f1-9b26-6a8e2ab625e4
+size=1Mib, type=21686148-6449-6E6F-744E-656564454649, name="BIOS"
+size=1Gib, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, name="boot"
+           type=4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709, name="root"
+EOF
+
+    truncate -s10G test-img.img
+
+    cat sfdisk-buf | sfdisk --wipe=always test-img.img
+
+    mkdir -p /var/mnt
+
+    # Also update kernel partition tables
+    loopdev=$(losetup --find --show --partscan test-img.img)
+    sleep 1
+
+    mkfs.ext4 "${loopdev}p3"
+    mount "${loopdev}p3" /var/mnt
+
+    # Need this for bootupd state
+    mkdir -p /var/mnt/boot
+
+    mkfs.ext4 "${loopdev}p2"
+    mount "${loopdev}p2" /var/mnt/boot
+}
+

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,16 +1,20 @@
 #!/bin/bash
 
+export DISK_IMAGE=/var/test-img.img
+export BOOT_TIMEOUT=600
+
 create_mount_device_bios() {
-    set +e
+    set -e
 
     mkdir -p /var/mnt
 
-    umount -R /var/mnt
-    losetup -j /var/test-img.img | cut -d: -f1 | xargs -r losetup -d
+    if mount | grep -qF /var/mnt; then
+        umount -R /var/mnt
+    fi
 
-    set -e
+    losetup -j "$DISK_IMAGE" | cut -d: -f1 | xargs -r losetup -d
 
-    rm -rfv /var/test-img.img
+    rm -rfv "$DISK_IMAGE"
 
     cat <<-EOF > sfdisk-buf
 label: gpt
@@ -20,15 +24,13 @@ size=1Gib, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, name="boot"
            type=4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709, name="root"
 EOF
 
-    truncate -s10G /var/test-img.img
+    truncate -s10G "$DISK_IMAGE"
 
-    cat sfdisk-buf | sfdisk --wipe=always /var/test-img.img
+    cat sfdisk-buf | sfdisk --wipe=always "$DISK_IMAGE"
 
     # Also update kernel partition tables
-    loopdev=$(losetup --find --show --partscan /var/test-img.img)
+    loopdev=$(losetup --find --show --partscan "$DISK_IMAGE")
     sleep 1
-
-    # mkfs.vfat "${loopdev}p3"
 
     mkfs.ext4 "${loopdev}p3"
     mount "${loopdev}p3" /var/mnt
@@ -45,12 +47,12 @@ run_bootupctl_bios() {
 
     IMG_NAME=$1
 
-    DEVICE=$(losetup -j /var/test-img.img | cut -d: -f1)
+    DEVICE=$(losetup -j "$DISK_IMAGE" | cut -d: -f1)
 
     # Skip IMG_NAME
     local bootloader=("${@:2}")
 
-    podman run --rm --net=host --privileged --pid=host \
+    podman run --rm --net=host --pid=host \
       --privileged \
       --security-opt label=type:unconfined_t \
       --env RUST_LOG=trace \

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -3,6 +3,8 @@
 create_mount_device_bios() {
     set +e
 
+    mkdir -p /var/mnt
+
     umount -R /var/mnt
     losetup -j /var/test-img.img | cut -d: -f1 | xargs -r losetup -d
 
@@ -22,11 +24,11 @@ EOF
 
     cat sfdisk-buf | sfdisk --wipe=always /var/test-img.img
 
-    mkdir -p /var/mnt
-
     # Also update kernel partition tables
     loopdev=$(losetup --find --show --partscan /var/test-img.img)
     sleep 1
+
+    # mkfs.vfat "${loopdev}p3"
 
     mkfs.ext4 "${loopdev}p3"
     mount "${loopdev}p3" /var/mnt

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -8,7 +8,7 @@ create_mount_device_bios() {
 
     set -e
 
-    rm -rfv test-img.img
+    rm -rfv /var/test-img.img
 
     cat <<-EOF > sfdisk-buf
 label: gpt
@@ -18,14 +18,14 @@ size=1Gib, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, name="boot"
            type=4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709, name="root"
 EOF
 
-    truncate -s10G test-img.img
+    truncate -s10G /var/test-img.img
 
-    cat sfdisk-buf | sfdisk --wipe=always test-img.img
+    cat sfdisk-buf | sfdisk --wipe=always /var/test-img.img
 
     mkdir -p /var/mnt
 
     # Also update kernel partition tables
-    loopdev=$(losetup --find --show --partscan test-img.img)
+    loopdev=$(losetup --find --show --partscan /var/test-img.img)
     sleep 1
 
     mkfs.ext4 "${loopdev}p3"

--- a/scripts/test-bios-bootc-install.sh
+++ b/scripts/test-bios-bootc-install.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Test whether a VM created with BIOS only boots or not
+
+set -eux
+
+. ./helpers.sh
+
+create_mount_device_bios
+
+IMAGE=$1
+
+podman run --rm --net=host --privileged --pid=host \
+  --privileged \
+  --security-opt label=type:unconfined_t \
+  --env RUST_LOG=debug \
+  --env BOOTC_BOOTLOADER_DEBUG=1 \
+  -v /dev:/dev \
+  -v /var/mnt:/var/mnt \
+  "$IMAGE" \
+    bootc install to-filesystem --karg console=ttyS0,115500n --skip-fetch-check \
+    --acknowledge-destructive --disable-selinux /var/mnt

--- a/scripts/test-bios-bootc-install.sh
+++ b/scripts/test-bios-bootc-install.sh
@@ -20,7 +20,7 @@ podman run --rm --net=host --pid=host \
   -v /dev:/dev \
   -v /var/mnt:/var/mnt \
   "$IMAGE" \
-    bootc install to-filesystem --bootloader=none --karg console=ttyS0,115500n --skip-fetch-check \
+    bootc install to-filesystem --bootloader=none --karg console=ttyS0,115200n --skip-fetch-check \
     --acknowledge-destructive --disable-selinux /var/mnt
 
 # Make sure the mount is actually writable

--- a/scripts/test-bios-bootc-install.sh
+++ b/scripts/test-bios-bootc-install.sh
@@ -2,6 +2,8 @@
 
 # Test whether a VM created with BIOS only boots or not
 
+cd "$(dirname "$0")"
+
 set -eux
 
 . ./helpers.sh
@@ -10,7 +12,7 @@ create_mount_device_bios
 
 IMAGE=$1
 
-podman run --rm --net=host --privileged --pid=host \
+podman run --rm --net=host --pid=host \
   --privileged \
   --security-opt label=type:unconfined_t \
   --env RUST_LOG=debug \
@@ -18,5 +20,10 @@ podman run --rm --net=host --privileged --pid=host \
   -v /dev:/dev \
   -v /var/mnt:/var/mnt \
   "$IMAGE" \
-    bootc install to-filesystem --karg console=ttyS0,115500n --skip-fetch-check \
+    bootc install to-filesystem --bootloader=none --karg console=ttyS0,115500n --skip-fetch-check \
     --acknowledge-destructive --disable-selinux /var/mnt
+
+# Make sure the mount is actually writable
+mount -o remount,rw /var/mnt/boot
+
+run_bootupctl_bios "$IMAGE"

--- a/scripts/test-bios-install.sh
+++ b/scripts/test-bios-install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd "$(dirname "$0")"
+
 set -u
 IMG_NAME=$1
 
@@ -7,33 +9,18 @@ set -x
 
 . ./helpers.sh
 
-run_podman() {
-    set +eu
-
-    local bootloader=("$@")
-
-    podman run --rm --net=host --privileged --pid=host \
-      --privileged \
-      --security-opt label=type:unconfined_t \
-      --env RUST_LOG=trace \
-      -v /dev:/dev \
-      -v /var/mnt:/var/mnt \
-      "$IMG_NAME" \
-      bootupctl backend install "${bootloader[@]}" --device /dev/loop0 --auto /var/mnt -vvvv
-}
-
 create_mount_device_bios
 # This SHOULD fail
-if run_podman "--bootloader" "systemd"; then echo "Bootloader systemd with BIOS should have failed"; exit 1; fi
+if run_bootupctl_bios "$IMG_NAME"  "--bootloader" "systemd"; then echo "Bootloader systemd with BIOS should have failed"; exit 1; fi
 
 create_mount_device_bios
 # This SHOULD also fail
-if run_podman "--bootloader" "grub-cc"; then echo "Bootloader GrubCC with BIOS should have failed"; exit 1; fi
+if run_bootupctl_bios  "$IMG_NAME" "--bootloader" "grub-cc"; then echo "Bootloader GrubCC with BIOS should have failed"; exit 1; fi
 
 create_mount_device_bios
 # This SHOULD pass
-if ! run_podman "--bootloader" "grub"; then echo "Bootloader Grub with BIOS should have passed"; exit 1; fi
+if ! run_bootupctl_bios "$IMG_NAME" "--bootloader" "grub"; then echo "Bootloader Grub with BIOS should have passed"; exit 1; fi
 
 create_mount_device_bios
 # This SHOULD pass
-if ! run_podman; then echo "Bootloader None (auto detected as grub) with BIOS should have passed"; exit 1; fi
+if ! run_bootupctl_bios "$IMG_NAME"; then echo "Bootloader None (auto detected as grub) with BIOS should have passed"; exit 1; fi

--- a/scripts/test-bios-install.sh
+++ b/scripts/test-bios-install.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -u
+IMG_NAME=$1
+
+set -x
+
+. ./helpers.sh
+
+run_podman() {
+    set +eu
+
+    local bootloader=("$@")
+
+    podman run --rm --net=host --privileged --pid=host \
+      --privileged \
+      --security-opt label=type:unconfined_t \
+      --env RUST_LOG=trace \
+      -v /dev:/dev \
+      -v /var/mnt:/var/mnt \
+      "$IMG_NAME" \
+      bootupctl backend install "${bootloader[@]}" --device /dev/loop0 --auto /var/mnt -vvvv
+}
+
+create_mount_device_bios
+# This SHOULD fail
+if run_podman "--bootloader" "systemd"; then echo "Bootloader systemd with BIOS should have failed"; exit 1; fi
+
+create_mount_device_bios
+# This SHOULD also fail
+if run_podman "--bootloader" "grub-cc"; then echo "Bootloader GrubCC with BIOS should have failed"; exit 1; fi
+
+create_mount_device_bios
+# This SHOULD pass
+if ! run_podman "--bootloader" "grub"; then echo "Bootloader Grub with BIOS should have passed"; exit 1; fi
+
+create_mount_device_bios
+# This SHOULD pass
+if ! run_podman; then echo "Bootloader None (auto detected as grub) with BIOS should have passed"; exit 1; fi

--- a/scripts/test-bios-vm-boot.sh
+++ b/scripts/test-bios-vm-boot.sh
@@ -4,14 +4,17 @@
 # https://github.com/bootc-dev/bootc/pull/2314
 # which will let us use bootc install to-disk creating a BIOS partition
 
-set -ux
-set +e
+cd "$(dirname "$0")"
+
+set -eux
 
 IMAGE=$1
 DISK_IMAGE=/var/test-img.img
 TIMEOUT=300
 
 ./test-bios-bootc-install.sh "$IMAGE"
+
+set +e
 
 umount -R /var/mnt 2>/dev/null || true
 losetup -j "$DISK_IMAGE" | cut -d: -f1 | xargs -r losetup -d

--- a/scripts/test-bios-vm-boot.sh
+++ b/scripts/test-bios-vm-boot.sh
@@ -9,14 +9,17 @@ cd "$(dirname "$0")"
 set -eux
 
 IMAGE=$1
-DISK_IMAGE=/var/test-img.img
-TIMEOUT=300
+
+. ./helpers.sh
 
 ./test-bios-bootc-install.sh "$IMAGE"
 
+if mount | grep -qF /var/mnt; then
+    umount -R /var/mnt
+fi
+
 set +e
 
-umount -R /var/mnt 2>/dev/null || true
 losetup -j "$DISK_IMAGE" | cut -d: -f1 | xargs -r losetup -d
 
 set -e
@@ -24,7 +27,7 @@ set -e
 SERIAL_LOG=$(mktemp /tmp/qemu-serial-XXXXXX.log)
 trap 'cat "$SERIAL_LOG"' EXIT
 
-echo "Booting '$DISK_IMAGE' with QEMU (BIOS mode, timeout=${TIMEOUT}s)..."
+echo "Booting '$DISK_IMAGE' with QEMU (BIOS mode, timeout=${BOOT_TIMEOUT}s)..."
 echo "Serial log: $SERIAL_LOG"
 
 qemu-system-x86_64 \
@@ -32,7 +35,7 @@ qemu-system-x86_64 \
     -cpu host \
     -enable-kvm \
     -m 2048 \
-    -nographic \
+    -display none \
     -serial file:"$SERIAL_LOG" \
     -drive file="$DISK_IMAGE",format=raw,if=virtio \
     -boot c \
@@ -43,7 +46,7 @@ QEMU_PID=$!
 boot_ok=0
 elapsed=0
 
-while [ "$elapsed" -lt "$TIMEOUT" ]; do
+while [ "$elapsed" -lt "$BOOT_TIMEOUT" ]; do
     if ! kill -0 "$QEMU_PID" 2>/dev/null; then
         echo "QEMU exited prematurely after ${elapsed}s."
         break
@@ -64,12 +67,12 @@ if kill -0 "$QEMU_PID" 2>/dev/null; then
     wait "$QEMU_PID" 2>/dev/null || true
 fi
 
-cat "$SERIAL_LOG"
+rm -rf "$DISK_IMAGE"
 
 if [ "$boot_ok" -eq 1 ]; then
     echo "PASS: VM booted successfully (detected in ${elapsed}s)."
     exit 0
 else
-    echo "FAIL: VM did not boot within ${TIMEOUT}s."
+    echo "FAIL: VM did not boot within ${BOOT_TIMEOUT}s."
     exit 1
 fi

--- a/scripts/test-bios-vm-boot.sh
+++ b/scripts/test-bios-vm-boot.sh
@@ -8,7 +8,7 @@ set -ux
 set +e
 
 IMAGE=$1
-DISK_IMAGE=test-img.img
+DISK_IMAGE=/var/test-img.img
 TIMEOUT=300
 
 ./test-bios-bootc-install.sh "$IMAGE"

--- a/scripts/test-bios-vm-boot.sh
+++ b/scripts/test-bios-vm-boot.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# TODO(Johan-Liebert1): We can replace this entire thing with bcvk once we have
+# https://github.com/bootc-dev/bootc/pull/2314
+# which will let us use bootc install to-disk creating a BIOS partition
+
+set -ux
+set +e
+
+DISK_IMAGE="${1:-test-img.img}"
+TIMEOUT=300
+
+./test-bios-bootc-install.sh
+
+umount -R /var/mnt 2>/dev/null || true
+losetup -j "$DISK_IMAGE" | cut -d: -f1 | xargs -r losetup -d
+
+set -e
+
+SERIAL_LOG=$(mktemp /tmp/qemu-serial-XXXXXX.log)
+trap 'cat "$SERIAL_LOG"' EXIT
+
+echo "Booting '$DISK_IMAGE' with QEMU (BIOS mode, timeout=${TIMEOUT}s)..."
+echo "Serial log: $SERIAL_LOG"
+
+qemu-system-x86_64 \
+    -machine pc \
+    -cpu host \
+    -enable-kvm \
+    -m 2048 \
+    -nographic \
+    -serial file:"$SERIAL_LOG" \
+    -drive file="$DISK_IMAGE",format=raw,if=virtio \
+    -boot c \
+    -no-reboot &
+
+QEMU_PID=$!
+
+boot_ok=0
+elapsed=0
+
+while [ "$elapsed" -lt "$TIMEOUT" ]; do
+    if ! kill -0 "$QEMU_PID" 2>/dev/null; then
+        echo "QEMU exited prematurely after ${elapsed}s."
+        break
+    fi
+
+    if grep -qiE 'login:|welcome to|reached target.*multi-user' "$SERIAL_LOG" 2>/dev/null; then
+        boot_ok=1
+        break
+    fi
+
+    sleep 5
+    elapsed=$((elapsed + 5))
+done
+
+# Shut down QEMU
+if kill -0 "$QEMU_PID" 2>/dev/null; then
+    kill "$QEMU_PID"
+    wait "$QEMU_PID" 2>/dev/null || true
+fi
+
+cat "$SERIAL_LOG"
+
+if [ "$boot_ok" -eq 1 ]; then
+    echo "PASS: VM booted successfully (detected in ${elapsed}s)."
+    exit 0
+else
+    echo "FAIL: VM did not boot within ${TIMEOUT}s."
+    exit 1
+fi

--- a/scripts/test-bootloader.sh
+++ b/scripts/test-bootloader.sh
@@ -50,7 +50,7 @@ mount "${loopdev}p1" $ESP
 
 
 # Test installing the bootloader
-podman run --rm --net=host --privileged --pid=host \
+podman run --rm --net=host --pid=host \
   --privileged \
   --security-opt label=type:unconfined_t \
   --env RUST_LOG=trace \

--- a/scripts/test-uefi-bootc-install.sh
+++ b/scripts/test-uefi-bootc-install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+
+set -eux
+
+IMAGE=$1
+BACKEND=$2
+
+composefs=()
+
+if [[ "$BACKEND" == "composefs" ]]; then
+    composefs=(--composefs-backend)
+fi
+
+truncate -s10G /var/disk.img
+
+# We don't have bootupd support for GrubCC and SystemdBoot
+# in bootc yet
+podman run --rm --net=host --pid=host \
+  --privileged \
+  --security-opt label=type:unconfined_t \
+  --env RUST_LOG=debug \
+  --env BOOTC_BOOTLOADER_DEBUG=1 \
+  -v /dev:/dev \
+  "$IMAGE" \
+    bootc install to-filesystem "${composefs[@]}" --karg console=ttyS0,115200n8 --skip-fetch-check \
+    --generic-image --disable-selinux /var/test-img.img

--- a/scripts/test-uefi-bootc-install.sh
+++ b/scripts/test-uefi-bootc-install.sh
@@ -4,6 +4,8 @@ cd "$(dirname "$0")"
 
 set -eux
 
+. ./helpers.sh
+
 IMAGE=$1
 BACKEND=$2
 
@@ -13,7 +15,7 @@ if [[ "$BACKEND" == "composefs" ]]; then
     composefs=(--composefs-backend)
 fi
 
-truncate -s10G /var/disk.img
+truncate -s10G "$DISK_IMAGE"
 
 # We don't have bootupd support for GrubCC and SystemdBoot
 # in bootc yet
@@ -23,6 +25,8 @@ podman run --rm --net=host --pid=host \
   --env RUST_LOG=debug \
   --env BOOTC_BOOTLOADER_DEBUG=1 \
   -v /dev:/dev \
+  -v "$DISK_IMAGE":"$DISK_IMAGE" \
   "$IMAGE" \
-    bootc install to-filesystem "${composefs[@]}" --karg console=ttyS0,115200n8 --skip-fetch-check \
-    --generic-image --disable-selinux /var/test-img.img
+    bootc install to-disk --filesystem=ext4 --wipe \
+    "${composefs[@]}" --karg console=ttyS0,115200n8 \
+    --generic-image --via-loopback --disable-selinux "$DISK_IMAGE"

--- a/scripts/test-uefi-vm-boot.sh
+++ b/scripts/test-uefi-vm-boot.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd "$(dirname "$0")"
+
 set -eux
 
 IMAGE=$1

--- a/scripts/test-uefi-vm-boot.sh
+++ b/scripts/test-uefi-vm-boot.sh
@@ -1,36 +1,50 @@
 #!/bin/bash
 
-# TODO(Johan-Liebert1): We can replace this entire thing with bcvk once we have
-# https://github.com/bootc-dev/bootc/pull/2314
-# which will let us use bootc install to-disk creating a BIOS partition
-
-set -ux
-set +e
+set -eux
 
 IMAGE=$1
-DISK_IMAGE=test-img.img
+BACKEND=$2
+DISK_IMAGE=/var/test-img.img
 TIMEOUT=300
 
-./test-bios-bootc-install.sh "$IMAGE"
+./test-uefi-bootc-install.sh "$IMAGE" "$BACKEND"
+
+set +e
 
 umount -R /var/mnt 2>/dev/null || true
 losetup -j "$DISK_IMAGE" | cut -d: -f1 | xargs -r losetup -d
 
 set -e
 
-SERIAL_LOG=$(mktemp /tmp/qemu-serial-XXXXXX.log)
-trap 'cat "$SERIAL_LOG"' EXIT
+# Find OVMF firmware
+OVMF_CODE=/usr/share/OVMF/OVMF_CODE_4M.fd
+if [ ! -f "$OVMF_CODE" ]; then
+    OVMF_CODE=/usr/share/OVMF/OVMF_CODE.fd
+fi
 
-echo "Booting '$DISK_IMAGE' with QEMU (BIOS mode, timeout=${TIMEOUT}s)..."
+OVMF_VARS_TEMPLATE=/usr/share/OVMF/OVMF_VARS_4M.fd
+if [ ! -f "$OVMF_VARS_TEMPLATE" ]; then
+    OVMF_VARS_TEMPLATE=/usr/share/OVMF/OVMF_VARS.fd
+fi
+
+OVMF_VARS=$(mktemp /tmp/ovmf-vars-XXXXXX.fd)
+cp "$OVMF_VARS_TEMPLATE" "$OVMF_VARS"
+
+SERIAL_LOG=$(mktemp /tmp/qemu-serial-XXXXXX.log)
+trap 'cat "$SERIAL_LOG"; rm -f "$OVMF_VARS"' EXIT
+
+echo "Booting '$DISK_IMAGE' with QEMU (UEFI mode, timeout=${TIMEOUT}s)..."
 echo "Serial log: $SERIAL_LOG"
 
 qemu-system-x86_64 \
-    -machine pc \
+    -machine q35 \
     -cpu host \
     -enable-kvm \
     -m 2048 \
     -nographic \
     -serial file:"$SERIAL_LOG" \
+    -drive if=pflash,format=raw,readonly=on,file="$OVMF_CODE" \
+    -drive if=pflash,format=raw,file="$OVMF_VARS" \
     -drive file="$DISK_IMAGE",format=raw,if=virtio \
     -boot c \
     -no-reboot &
@@ -46,7 +60,7 @@ while [ "$elapsed" -lt "$TIMEOUT" ]; do
         break
     fi
 
-    if grep -qiE 'login:|welcome to|reached target.*multi-user' "$SERIAL_LOG" 2>/dev/null; then
+    if grep -qiE 'login:|reached target.*multi-user' "$SERIAL_LOG" 2>/dev/null; then
         boot_ok=1
         break
     fi
@@ -61,10 +75,10 @@ if kill -0 "$QEMU_PID" 2>/dev/null; then
     wait "$QEMU_PID" 2>/dev/null || true
 fi
 
-cat "$SERIAL_LOG"
+rm -f "$DISK_IMAGE"
 
 if [ "$boot_ok" -eq 1 ]; then
-    echo "PASS: VM booted successfully (detected in ${elapsed}s)."
+    echo "PASS: VM booted successfully in UEFI mode (detected in ${elapsed}s)."
     exit 0
 else
     echo "FAIL: VM did not boot within ${TIMEOUT}s."

--- a/scripts/test-uefi-vm-boot.sh
+++ b/scripts/test-uefi-vm-boot.sh
@@ -4,16 +4,19 @@ cd "$(dirname "$0")"
 
 set -eux
 
+. ./helpers.sh
+
 IMAGE=$1
 BACKEND=$2
-DISK_IMAGE=/var/test-img.img
-TIMEOUT=300
 
 ./test-uefi-bootc-install.sh "$IMAGE" "$BACKEND"
 
 set +e
 
-umount -R /var/mnt 2>/dev/null || true
+if mount | grep -qF /var/mnt; then
+    umount -R /var/mnt
+fi
+
 losetup -j "$DISK_IMAGE" | cut -d: -f1 | xargs -r losetup -d
 
 set -e
@@ -35,7 +38,7 @@ cp "$OVMF_VARS_TEMPLATE" "$OVMF_VARS"
 SERIAL_LOG=$(mktemp /tmp/qemu-serial-XXXXXX.log)
 trap 'cat "$SERIAL_LOG"; rm -f "$OVMF_VARS"' EXIT
 
-echo "Booting '$DISK_IMAGE' with QEMU (UEFI mode, timeout=${TIMEOUT}s)..."
+echo "Booting '$DISK_IMAGE' with QEMU (UEFI mode, timeout=${BOOT_TIMEOUT}s)..."
 echo "Serial log: $SERIAL_LOG"
 
 qemu-system-x86_64 \
@@ -43,7 +46,7 @@ qemu-system-x86_64 \
     -cpu host \
     -enable-kvm \
     -m 2048 \
-    -nographic \
+    -display none \
     -serial file:"$SERIAL_LOG" \
     -drive if=pflash,format=raw,readonly=on,file="$OVMF_CODE" \
     -drive if=pflash,format=raw,file="$OVMF_VARS" \
@@ -56,13 +59,13 @@ QEMU_PID=$!
 boot_ok=0
 elapsed=0
 
-while [ "$elapsed" -lt "$TIMEOUT" ]; do
+while [ "$elapsed" -lt "$BOOT_TIMEOUT" ]; do
     if ! kill -0 "$QEMU_PID" 2>/dev/null; then
         echo "QEMU exited prematurely after ${elapsed}s."
         break
     fi
 
-    if grep -qiE 'login:|reached target.*multi-user' "$SERIAL_LOG" 2>/dev/null; then
+    if grep -qiE 'login:|welcome to|reached target.*multi-user' "$SERIAL_LOG" 2>/dev/null; then
         boot_ok=1
         break
     fi
@@ -83,6 +86,6 @@ if [ "$boot_ok" -eq 1 ]; then
     echo "PASS: VM booted successfully in UEFI mode (detected in ${elapsed}s)."
     exit 0
 else
-    echo "FAIL: VM did not boot within ${TIMEOUT}s."
+    echo "FAIL: VM did not boot within ${BOOT_TIMEOUT}s."
     exit 1
 fi

--- a/src/backend/statefile.rs
+++ b/src/backend/statefile.rs
@@ -136,8 +136,20 @@ impl SavedState {
                 }
 
                 #[cfg(efi_arch)]
-                Bootloader::GrubCC | Bootloader::Systemd => {
-                    use crate::efi::Efi;
+                b @ Bootloader::GrubCC | b @ Bootloader::Systemd => {
+                    use crate::efi::{is_efi_booted, Efi};
+
+                    // Using just `cfg(efi_arch)` is insufficient here, as if the binary's
+                    // built on x86, but the target system is only BIOS, then we WILL enter
+                    // this branch which is less than ideal
+
+                    if !is_efi_booted()? {
+                        log::debug!(
+                            "Testing saved state for {b}, but system is not EFI booted. Skipping"
+                        );
+                        return Ok(None);
+                    }
+
                     let efi = Efi::default();
 
                     let device = get_parent_device(&root)?;

--- a/src/bootupd.rs
+++ b/src/bootupd.rs
@@ -55,26 +55,16 @@ impl ConfigMode {
 }
 
 pub(crate) fn install(opts: &InstallOpts, devices: &[Device], configs: ConfigMode) -> Result<()> {
-    // SavedState needs to be per component
-    // Consider this scenario:
-    // - Grub installed (statefile in /sysroot/boot)
-    // - Re-install attempted with GrubCC
-    //
-    // So we can't just check statefile based on the determined bootloader
-    // We need to check all cases
-    for b in Bootloader::iter() {
-        SavedState::ensure_not_present(&opts.dest_root, b)
-            .context("failed to install, invalid re-install attempted")?;
+    let all_components = get_components_impl(opts.auto);
+
+    if all_components.is_empty() {
+        println!("No components available for this platform.");
+        return Ok(());
     }
 
     let source_root_dir = Dir::open_ambient_dir(&opts.src_root, ambient_authority())
         .context("Opening source root")?;
 
-    let all_components = get_components_impl(opts.auto);
-    if all_components.is_empty() {
-        println!("No components available for this platform.");
-        return Ok(());
-    }
     let target_components = if let Some(target_components) = &opts.components {
         // Checked by CLI parser
         assert!(!opts.auto);
@@ -92,6 +82,36 @@ pub(crate) fn install(opts: &InstallOpts, devices: &[Device], configs: ConfigMod
 
     if target_components.is_empty() && !opts.auto {
         anyhow::bail!("No components specified");
+    }
+
+    log::debug!(
+        "Auto: {}, Target components: {:?}",
+        opts.auto,
+        target_components
+            .iter()
+            .map(|c| c.name())
+            .collect::<Vec<_>>()
+    );
+
+    let has_efi_component = target_components
+        .iter()
+        .any(|c| c.component_type() == ComponentType::Efi);
+
+    // SavedState needs to be per component
+    // Consider this scenario:
+    // - Grub installed (statefile in /sysroot/boot)
+    // - Re-install attempted with GrubCC
+    //
+    // So we can't just check statefile based on the determined bootloader
+    // We need to check all cases
+    for b in Bootloader::iter() {
+        if !has_efi_component && b != Bootloader::Grub {
+            log::debug!("Skipping bootloader {b} as there's no EFI component");
+            continue;
+        }
+
+        SavedState::ensure_not_present(&opts.dest_root, b)
+            .context("failed to install, invalid re-install attempted")?;
     }
 
     #[cfg(efi_arch)]

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -83,6 +83,7 @@ fn is_mount_point(path: &Path) -> Result<bool> {
 }
 
 /// Return `true` if the system is booted via EFI
+#[context("Checking if system is EFI booted")]
 pub(crate) fn is_efi_booted() -> Result<bool> {
     Path::new("/sys/firmware/efi")
         .try_exists()

--- a/src/sha512string.rs
+++ b/src/sha512string.rs
@@ -46,7 +46,10 @@ mod test {
     fn test_empty() -> Result<()> {
         let mut h = Hasher::new(openssl::hash::MessageDigest::sha512())?;
         let s = SHA512String::from_hasher(&mut h);
-        assert_eq!("sha512:cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e", format!("{}", s));
+        assert_eq!(
+            "sha512:cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
+            format!("{}", s)
+        );
         Ok(())
     }
 


### PR DESCRIPTION
state: Skip state check for GrubCC and Systemd on non-efi systems

We were relying on `cfg(efi_arch)` to check for the existence of
bootupd's statefile, but that's not correct.

Using just `cfg(efi_arch)` is insufficient, as if the binary's
built on x86, but the target system is only BIOS, then we WILL enter
the branch which will want to check the statefile in the ESP and will
encounter an error.

Also, skip statefile check if we're only installing for BIOS and we do
not have EFI component

---

tests: Add bootc install tests for BIOS and UEFI

Also check whether the final VM boots or not

Related to: #1139