### PR TITLE
ci: extend testing to CentOS 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,25 +26,33 @@ jobs:
           - ubuntu-24.04-arm
         grubcc:
           - 0
-          - 1
+        stream:
+          - 9
+          - 10
+        include:
+          # grubcc=1 uses Fedora (Dockerfile.bls), no stream variants needed
+          - runner: ubuntu-24.04
+            grubcc: 1
+          - runner: ubuntu-24.04-arm
+            grubcc: 1
 
     runs-on: [ "${{ matrix.runner }}" ]
 
     steps:
       - name: Setup env
         run: |
-          IMG_NAME=localhost/bootupd-grubcc-${{ matrix.grubcc }}
-          echo "IMG_NAME=${IMG_NAME}" >> $GITHUB_ENV
-
           if [[ "${{ matrix.grubcc }}" == "1" ]]; then
-            # we only have grub-cc in feodra (for now)
+            # grubcc=1 uses Fedora (no stream variants)
+            IMG_NAME=localhost/bootupd-grubcc-1
             OS_ID="fedora"
           else
+            IMG_NAME=localhost/bootupd-grubcc-0-stream${{ matrix.stream }}
             OS_ID="centos"
           fi
 
-          echo "OS_ID=${OS_ID}" >> $GITHUB_ENV
-      
+          echo "IMG_NAME=${IMG_NAME}" >> "$GITHUB_ENV"
+          echo "OS_ID=${OS_ID}" >> "$GITHUB_ENV"
+
       - name: Get a newer podman for heredoc support (from debian testing)
         run: |
           set -eux
@@ -70,12 +78,12 @@ jobs:
 
       - name: build with grubcc=${{ matrix.grubcc }}
         run: |
-          dockerfile=Dockerfile
-          build_args=()
-
           if [[ "${{ matrix.grubcc }}" == "1" ]]; then
             dockerfile=Dockerfile.bls
             build_args=(--build-arg "grubcc=${{ matrix.grubcc }}")
+          else
+            dockerfile=Dockerfile
+            build_args=(--build-arg "base=quay.io/centos-bootc/centos-bootc:stream${{ matrix.stream }}")
           fi
 
           sudo podman build "${build_args[@]}" . -t "$IMG_NAME"  -f "$dockerfile"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-# Build from the current git into a c9s-bootc container image.
-# Use e.g. --build-arg=base=quay.io/fedora/fedora-bootc:41 to target
-# Fedora or another base image instead.
+# Build from the current git into a centos-bootc container image.
+# Use e.g. --build-arg=base=quay.io/centos-bootc/centos-bootc:stream10
+# for CentOS Stream 10, or
+# --build-arg=base=quay.io/fedora/fedora-bootc:41 to target Fedora.
 #
 ARG base=quay.io/centos-bootc/centos-bootc:stream9
 
@@ -26,8 +27,11 @@ COPY --from=build /out/ /
 # Install bootc from copr
 RUN <<EORUN
 set -xeuo pipefail
+source /etc/os-release
 dnf -y install dnf-plugins-core
-dnf -y copr enable rhcontainerbot/bootc centos-stream-9-x86_64
+if [ "$ID" = "centos" ]; then
+  dnf -y copr enable rhcontainerbot/bootc centos-stream-${VERSION_ID}-$(uname -m)
+fi
 dnf -y install bootc
 dnf clean all
 rm -rf /var/log


### PR DESCRIPTION
Closes https://github.com/coreos/bootupd/issues/1120

Also tried enabling auto-detection of the CHROOT in that `dnf copr enable` call in the `Dockerfile`, but that didn't work. We need to continue to specify it manually.